### PR TITLE
Fix typo in class name

### DIFF
--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -266,7 +266,7 @@
                     <div class="col-lg-6">
                         <div class="panel panel-default">
                             <div class="panel-heading">
-                                Dismissable Alerts
+                                Dismissible Alerts
                             </div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -270,19 +270,19 @@
                             </div>
                             <!-- /.panel-heading -->
                             <div class="panel-body">
-                                <div class="alert alert-success alert-dismissable">
+                                <div class="alert alert-success alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                                     Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
                                 </div>
-                                <div class="alert alert-info alert-dismissable">
+                                <div class="alert alert-info alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                                     Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
                                 </div>
-                                <div class="alert alert-warning alert-dismissable">
+                                <div class="alert alert-warning alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                                     Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
                                 </div>
-                                <div class="alert alert-danger alert-dismissable">
+                                <div class="alert alert-danger alert-dismissible">
                                     <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
                                     Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
                                 </div>
@@ -303,12 +303,12 @@
                             <!-- /.panel-heading -->
                             <div class="panel-body">
                                 <!-- Button trigger modal -->
-                                <button class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
+                                <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
                                     Launch Demo Modal
                                 </button>
                                 <!-- Modal -->
                                 <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                                    <div class="modal-dialog">
+                                    <div class="modal-dialog" role="document">
                                         <div class="modal-content">
                                             <div class="modal-header">
                                                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>


### PR DESCRIPTION
The bootstrap class name is alert-dismissible.  Added missing type attribute to button. Modal dialogs must have a role attribute of document.
(errors found with bootlint, im not that sharp)