### PR TITLE
Wrap Bootstrap Rows in Container Tags

### DIFF
--- a/css/startmin.css
+++ b/css/startmin.css
@@ -13,7 +13,7 @@ body {
 }
 
 #page-wrapper {
-    padding: 30px 15px 0 15px;
+    padding-top: 30px;
     min-height: 568px;
     background-color: #fff;
 }
@@ -22,7 +22,7 @@ body {
     #page-wrapper {
         position: inherit;
         margin-left: 250px;
-        padding: 30px 30px 0 30px;
+        padding: 30px 15px 0 15px;
         border-left: 1px solid #e7e7e7;
     }
 }

--- a/pages/buttons.html
+++ b/pages/buttons.html
@@ -234,191 +234,194 @@
 
             <!-- Page Content -->
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Buttons</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Buttons</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Default Buttons
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <h4>Normal Buttons</h4>
-                                <p>
-                                    <button type="button" class="btn btn-default">Default</button>
-                                    <button type="button" class="btn btn-primary">Primary</button>
-                                    <button type="button" class="btn btn-success">Success</button>
-                                    <button type="button" class="btn btn-info">Info</button>
-                                    <button type="button" class="btn btn-warning">Warning</button>
-                                    <button type="button" class="btn btn-danger">Danger</button>
-                                    <button type="button" class="btn btn-link">Link</button>
-                                </p>
-                                <br>
-                                <h4>Disabled Buttons</h4>
-                                <p>
-                                    <button type="button" class="btn btn-default disabled">Default</button>
-                                    <button type="button" class="btn btn-primary disabled">Primary</button>
-                                    <button type="button" class="btn btn-success disabled">Success</button>
-                                    <button type="button" class="btn btn-info disabled">Info</button>
-                                    <button type="button" class="btn btn-warning disabled">Warning</button>
-                                    <button type="button" class="btn btn-danger disabled">Danger</button>
-                                    <button type="button" class="btn btn-link disabled">Link</button>
-                                </p>
-                                <br>
-                                <h4>Button Sizes</h4>
-                                <p>
-                                    <button type="button" class="btn btn-primary btn-lg">Large button</button>
-                                    <button type="button" class="btn btn-primary">Default button</button>
-                                    <button type="button" class="btn btn-primary btn-sm">Small button</button>
-                                    <button type="button" class="btn btn-primary btn-xs">Mini button</button>
-                                    <br>
-                                    <br>
-                                    <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
-                                </p>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Circle Icon Buttons with Font Awesome Icons
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <h4>Normal Circle Buttons</h4>
-                                <button type="button" class="btn btn-default btn-circle"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-primary btn-circle"><i class="fa fa-list"></i></button>
-                                <button type="button" class="btn btn-success btn-circle"><i class="fa fa-link"></i></button>
-                                <button type="button" class="btn btn-info btn-circle"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-warning btn-circle"><i class="fa fa-times"></i></button>
-                                <button type="button" class="btn btn-danger btn-circle"><i class="fa fa-heart"></i></button>
-                                <br><br>
-                                <h4>Large Circle Buttons</h4>
-                                <button type="button" class="btn btn-default btn-circle btn-lg"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-primary btn-circle btn-lg"><i class="fa fa-list"></i></button>
-                                <button type="button" class="btn btn-success btn-circle btn-lg"><i class="fa fa-link"></i></button>
-                                <button type="button" class="btn btn-info btn-circle btn-lg"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-warning btn-circle btn-lg"><i class="fa fa-times"></i></button>
-                                <button type="button" class="btn btn-danger btn-circle btn-lg"><i class="fa fa-heart"></i></button>
-                                <br><br>
-                                <h4>Extra Large Circle Buttons</h4>
-                                <button type="button" class="btn btn-default btn-circle btn-xl"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-primary btn-circle btn-xl"><i class="fa fa-list"></i></button>
-                                <button type="button" class="btn btn-success btn-circle btn-xl"><i class="fa fa-link"></i></button>
-                                <button type="button" class="btn btn-info btn-circle btn-xl"><i class="fa fa-check"></i></button>
-                                <button type="button" class="btn btn-warning btn-circle btn-xl"><i class="fa fa-times"></i></button>
-                                <button type="button" class="btn btn-danger btn-circle btn-xl"><i class="fa fa-heart"></i></button>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Outline Buttons with Smooth Transition
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <h4>Outline Buttons</h4>
-                                <p>
-                                    <button type="button" class="btn btn-outline btn-default">Default</button>
-                                    <button type="button" class="btn btn-outline btn-primary">Primary</button>
-                                    <button type="button" class="btn btn-outline btn-success">Success</button>
-                                    <button type="button" class="btn btn-outline btn-info">Info</button>
-                                    <button type="button" class="btn btn-outline btn-warning">Warning</button>
-                                    <button type="button" class="btn btn-outline btn-danger">Danger</button>
-                                    <button type="button" class="btn btn-outline btn-link">Link</button>
-                                </p>
-                                <br>
-                                <h4>Outline Button Sizes</h4>
-                                <p>
-                                    <button type="button" class="btn btn-outline btn-primary btn-lg">Large button</button>
-                                    <button type="button" class="btn btn-outline btn-primary">Default button</button>
-                                    <button type="button" class="btn btn-outline btn-primary btn-sm">Small button</button>
-                                    <button type="button" class="btn btn-outline btn-primary btn-xs">Mini button</button>
-                                    <br>
-                                    <br>
-                                    <button type="button" class="btn btn-outline btn-primary btn-lg btn-block">Block level button</button>
-                                </p>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Social Buttons with Font Awesome Icons
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <a class="btn btn-block btn-social btn-bitbucket">
-                                    <i class="fa fa-bitbucket"></i> Sign in with Bitbucket
-                                </a>
-                                <a class="btn btn-block btn-social btn-dropbox">
-                                    <i class="fa fa-dropbox"></i> Sign in with Dropbox
-                                </a>
-                                <a class="btn btn-block btn-social btn-facebook">
-                                    <i class="fa fa-facebook"></i> Sign in with Facebook
-                                </a>
-                                <a class="btn btn-block btn-social btn-flickr">
-                                    <i class="fa fa-flickr"></i> Sign in with Flickr
-                                </a>
-                                <a class="btn btn-block btn-social btn-github">
-                                    <i class="fa fa-github"></i> Sign in with GitHub
-                                </a>
-                                <a class="btn btn-block btn-social btn-google-plus">
-                                    <i class="fa fa-google-plus"></i> Sign in with Google
-                                </a>
-                                <a class="btn btn-block btn-social btn-instagram">
-                                    <i class="fa fa-instagram"></i> Sign in with Instagram
-                                </a>
-                                <a class="btn btn-block btn-social btn-linkedin">
-                                    <i class="fa fa-linkedin"></i> Sign in with LinkedIn
-                                </a>
-                                <a class="btn btn-block btn-social btn-pinterest">
-                                    <i class="fa fa-pinterest"></i> Sign in with Pinterest
-                                </a>
-                                <a class="btn btn-block btn-social btn-tumblr">
-                                    <i class="fa fa-tumblr"></i> Sign in with Tumblr
-                                </a>
-                                <a class="btn btn-block btn-social btn-twitter">
-                                    <i class="fa fa-twitter"></i> Sign in with Twitter
-                                </a>
-                                <a class="btn btn-block btn-social btn-vk">
-                                    <i class="fa fa-vk"></i> Sign in with VK
-                                </a>
-
-                                <hr>
-
-                                <div class="text-center">
-                                    <a class="btn btn-social-icon btn-bitbucket"><i class="fa fa-bitbucket"></i></a>
-                                    <a class="btn btn-social-icon btn-dropbox"><i class="fa fa-dropbox"></i></a>
-                                    <a class="btn btn-social-icon btn-facebook"><i class="fa fa-facebook"></i></a>
-                                    <a class="btn btn-social-icon btn-flickr"><i class="fa fa-flickr"></i></a>
-                                    <a class="btn btn-social-icon btn-github"><i class="fa fa-github"></i></a>
-                                    <a class="btn btn-social-icon btn-google-plus"><i class="fa fa-google-plus"></i></a>
-                                    <a class="btn btn-social-icon btn-instagram"><i class="fa fa-instagram"></i></a>
-                                    <a class="btn btn-social-icon btn-linkedin"><i class="fa fa-linkedin"></i></a>
-                                    <a class="btn btn-social-icon btn-pinterest"><i class="fa fa-pinterest"></i></a>
-                                    <a class="btn btn-social-icon btn-tumblr"><i class="fa fa-tumblr"></i></a>
-                                    <a class="btn btn-social-icon btn-twitter"><i class="fa fa-twitter"></i></a>
-                                    <a class="btn btn-social-icon btn-vk"><i class="fa fa-vk"></i></a>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Default Buttons
                                 </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <h4>Normal Buttons</h4>
+                                    <p>
+                                        <button type="button" class="btn btn-default">Default</button>
+                                        <button type="button" class="btn btn-primary">Primary</button>
+                                        <button type="button" class="btn btn-success">Success</button>
+                                        <button type="button" class="btn btn-info">Info</button>
+                                        <button type="button" class="btn btn-warning">Warning</button>
+                                        <button type="button" class="btn btn-danger">Danger</button>
+                                        <button type="button" class="btn btn-link">Link</button>
+                                    </p>
+                                    <br>
+                                    <h4>Disabled Buttons</h4>
+                                    <p>
+                                        <button type="button" class="btn btn-default disabled">Default</button>
+                                        <button type="button" class="btn btn-primary disabled">Primary</button>
+                                        <button type="button" class="btn btn-success disabled">Success</button>
+                                        <button type="button" class="btn btn-info disabled">Info</button>
+                                        <button type="button" class="btn btn-warning disabled">Warning</button>
+                                        <button type="button" class="btn btn-danger disabled">Danger</button>
+                                        <button type="button" class="btn btn-link disabled">Link</button>
+                                    </p>
+                                    <br>
+                                    <h4>Button Sizes</h4>
+                                    <p>
+                                        <button type="button" class="btn btn-primary btn-lg">Large button</button>
+                                        <button type="button" class="btn btn-primary">Default button</button>
+                                        <button type="button" class="btn btn-primary btn-sm">Small button</button>
+                                        <button type="button" class="btn btn-primary btn-xs">Mini button</button>
+                                        <br>
+                                        <br>
+                                        <button type="button" class="btn btn-primary btn-lg btn-block">Block level button</button>
+                                    </p>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Circle Icon Buttons with Font Awesome Icons
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <h4>Normal Circle Buttons</h4>
+                                    <button type="button" class="btn btn-default btn-circle"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-primary btn-circle"><i class="fa fa-list"></i></button>
+                                    <button type="button" class="btn btn-success btn-circle"><i class="fa fa-link"></i></button>
+                                    <button type="button" class="btn btn-info btn-circle"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-warning btn-circle"><i class="fa fa-times"></i></button>
+                                    <button type="button" class="btn btn-danger btn-circle"><i class="fa fa-heart"></i></button>
+                                    <br><br>
+                                    <h4>Large Circle Buttons</h4>
+                                    <button type="button" class="btn btn-default btn-circle btn-lg"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-primary btn-circle btn-lg"><i class="fa fa-list"></i></button>
+                                    <button type="button" class="btn btn-success btn-circle btn-lg"><i class="fa fa-link"></i></button>
+                                    <button type="button" class="btn btn-info btn-circle btn-lg"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-warning btn-circle btn-lg"><i class="fa fa-times"></i></button>
+                                    <button type="button" class="btn btn-danger btn-circle btn-lg"><i class="fa fa-heart"></i></button>
+                                    <br><br>
+                                    <h4>Extra Large Circle Buttons</h4>
+                                    <button type="button" class="btn btn-default btn-circle btn-xl"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-primary btn-circle btn-xl"><i class="fa fa-list"></i></button>
+                                    <button type="button" class="btn btn-success btn-circle btn-xl"><i class="fa fa-link"></i></button>
+                                    <button type="button" class="btn btn-info btn-circle btn-xl"><i class="fa fa-check"></i></button>
+                                    <button type="button" class="btn btn-warning btn-circle btn-xl"><i class="fa fa-times"></i></button>
+                                    <button type="button" class="btn btn-danger btn-circle btn-xl"><i class="fa fa-heart"></i></button>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Outline Buttons with Smooth Transition
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <h4>Outline Buttons</h4>
+                                    <p>
+                                        <button type="button" class="btn btn-outline btn-default">Default</button>
+                                        <button type="button" class="btn btn-outline btn-primary">Primary</button>
+                                        <button type="button" class="btn btn-outline btn-success">Success</button>
+                                        <button type="button" class="btn btn-outline btn-info">Info</button>
+                                        <button type="button" class="btn btn-outline btn-warning">Warning</button>
+                                        <button type="button" class="btn btn-outline btn-danger">Danger</button>
+                                        <button type="button" class="btn btn-outline btn-link">Link</button>
+                                    </p>
+                                    <br>
+                                    <h4>Outline Button Sizes</h4>
+                                    <p>
+                                        <button type="button" class="btn btn-outline btn-primary btn-lg">Large button</button>
+                                        <button type="button" class="btn btn-outline btn-primary">Default button</button>
+                                        <button type="button" class="btn btn-outline btn-primary btn-sm">Small button</button>
+                                        <button type="button" class="btn btn-outline btn-primary btn-xs">Mini button</button>
+                                        <br>
+                                        <br>
+                                        <button type="button" class="btn btn-outline btn-primary btn-lg btn-block">Block level button</button>
+                                    </p>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Social Buttons with Font Awesome Icons
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <a class="btn btn-block btn-social btn-bitbucket">
+                                        <i class="fa fa-bitbucket"></i> Sign in with Bitbucket
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-dropbox">
+                                        <i class="fa fa-dropbox"></i> Sign in with Dropbox
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-facebook">
+                                        <i class="fa fa-facebook"></i> Sign in with Facebook
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-flickr">
+                                        <i class="fa fa-flickr"></i> Sign in with Flickr
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-github">
+                                        <i class="fa fa-github"></i> Sign in with GitHub
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-google-plus">
+                                        <i class="fa fa-google-plus"></i> Sign in with Google
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-instagram">
+                                        <i class="fa fa-instagram"></i> Sign in with Instagram
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-linkedin">
+                                        <i class="fa fa-linkedin"></i> Sign in with LinkedIn
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-pinterest">
+                                        <i class="fa fa-pinterest"></i> Sign in with Pinterest
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-tumblr">
+                                        <i class="fa fa-tumblr"></i> Sign in with Tumblr
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-twitter">
+                                        <i class="fa fa-twitter"></i> Sign in with Twitter
+                                    </a>
+                                    <a class="btn btn-block btn-social btn-vk">
+                                        <i class="fa fa-vk"></i> Sign in with VK
+                                    </a>
+
+                                    <hr>
+
+                                    <div class="text-center">
+                                        <a class="btn btn-social-icon btn-bitbucket"><i class="fa fa-bitbucket"></i></a>
+                                        <a class="btn btn-social-icon btn-dropbox"><i class="fa fa-dropbox"></i></a>
+                                        <a class="btn btn-social-icon btn-facebook"><i class="fa fa-facebook"></i></a>
+                                        <a class="btn btn-social-icon btn-flickr"><i class="fa fa-flickr"></i></a>
+                                        <a class="btn btn-social-icon btn-github"><i class="fa fa-github"></i></a>
+                                        <a class="btn btn-social-icon btn-google-plus"><i class="fa fa-google-plus"></i></a>
+                                        <a class="btn btn-social-icon btn-instagram"><i class="fa fa-instagram"></i></a>
+                                        <a class="btn btn-social-icon btn-linkedin"><i class="fa fa-linkedin"></i></a>
+                                        <a class="btn btn-social-icon btn-pinterest"><i class="fa fa-pinterest"></i></a>
+                                        <a class="btn btn-social-icon btn-tumblr"><i class="fa fa-tumblr"></i></a>
+                                        <a class="btn btn-social-icon btn-twitter"><i class="fa fa-twitter"></i></a>
+                                        <a class="btn btn-social-icon btn-vk"><i class="fa fa-vk"></i></a>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
                     </div>
-                    <!-- /.col-lg-6 -->
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/flot.html
+++ b/pages/flot.html
@@ -236,111 +236,114 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Flot</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Flot</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Line Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="flot-chart">
+                                        <div class="flot-chart-content" id="flot-line-chart"></div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-12 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Pie Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="flot-chart">
+                                        <div class="flot-chart-content" id="flot-pie-chart"></div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Multiple Axes Line Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="flot-chart">
+                                        <div class="flot-chart-content" id="flot-line-chart-multi"></div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Moving Line Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="flot-chart">
+                                        <div class="flot-chart-content" id="flot-line-chart-moving"></div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Bar Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="flot-chart">
+                                        <div class="flot-chart-content" id="flot-bar-chart"></div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Flot Charts Usage
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <p>Flot is a pure JavaScript plotting library for jQuery, with a focus on simple usage, attractive looks, and interactive features. In SB Admin, we are using the most recent version of Flot along with a few plugins to enhance the user experience. The Flot plugins being used are the tooltip plugin for hoverable tooltips, and the resize plugin for fully responsive charts. The documentation for Flot Charts is available on their website, <a target="_blank" href="http://www.flotcharts.org/">http://www.flotcharts.org/</a>.</p>
+                                    <a target="_blank" class="btn btn-default btn-lg btn-block" href="http://www.flotcharts.org/">View Flot Charts Documentation</a>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Line Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="flot-chart">
-                                    <div class="flot-chart-content" id="flot-line-chart"></div>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-12 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Pie Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="flot-chart">
-                                    <div class="flot-chart-content" id="flot-pie-chart"></div>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Multiple Axes Line Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="flot-chart">
-                                    <div class="flot-chart-content" id="flot-line-chart-multi"></div>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Moving Line Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="flot-chart">
-                                    <div class="flot-chart-content" id="flot-line-chart-moving"></div>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Bar Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="flot-chart">
-                                    <div class="flot-chart-content" id="flot-bar-chart"></div>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Flot Charts Usage
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <p>Flot is a pure JavaScript plotting library for jQuery, with a focus on simple usage, attractive looks, and interactive features. In SB Admin, we are using the most recent version of Flot along with a few plugins to enhance the user experience. The Flot plugins being used are the tooltip plugin for hoverable tooltips, and the resize plugin for fully responsive charts. The documentation for Flot Charts is available on their website, <a target="_blank" href="http://www.flotcharts.org/">http://www.flotcharts.org/</a>.</p>
-                                <a target="_blank" class="btn btn-default btn-lg btn-block" href="http://www.flotcharts.org/">View Flot Charts Documentation</a>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/forms.html
+++ b/pages/forms.html
@@ -230,206 +230,209 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Forms</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Forms</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Basic Form Elements
-                            </div>
-                            <div class="panel-body">
-                                <div class="row">
-                                    <div class="col-lg-6">
-                                        <form role="form">
-                                            <div class="form-group">
-                                                <label>Text Input</label>
-                                                <input class="form-control">
-                                                <p class="help-block">Example block-level help text here.</p>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Text Input with Placeholder</label>
-                                                <input class="form-control" placeholder="Enter text">
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Static Control</label>
-                                                <p class="form-control-static">email@example.com</p>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>File input</label>
-                                                <input type="file">
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Text area</label>
-                                                <textarea class="form-control" rows="3"></textarea>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Checkboxes</label>
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox" value="">Checkbox 1
-                                                    </label>
-                                                </div>
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox" value="">Checkbox 2
-                                                    </label>
-                                                </div>
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox" value="">Checkbox 3
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Inline Checkboxes</label>
-                                                <label class="checkbox-inline">
-                                                    <input type="checkbox">1
-                                                </label>
-                                                <label class="checkbox-inline">
-                                                    <input type="checkbox">2
-                                                </label>
-                                                <label class="checkbox-inline">
-                                                    <input type="checkbox">3
-                                                </label>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Radio Buttons</label>
-                                                <div class="radio">
-                                                    <label>
-                                                        <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>Radio 1
-                                                    </label>
-                                                </div>
-                                                <div class="radio">
-                                                    <label>
-                                                        <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">Radio 2
-                                                    </label>
-                                                </div>
-                                                <div class="radio">
-                                                    <label>
-                                                        <input type="radio" name="optionsRadios" id="optionsRadios3" value="option3">Radio 3
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Inline Radio Buttons</label>
-                                                <label class="radio-inline">
-                                                    <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline1" value="option1" checked>1
-                                                </label>
-                                                <label class="radio-inline">
-                                                    <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline2" value="option2">2
-                                                </label>
-                                                <label class="radio-inline">
-                                                    <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline3" value="option3">3
-                                                </label>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Selects</label>
-                                                <select class="form-control">
-                                                    <option>1</option>
-                                                    <option>2</option>
-                                                    <option>3</option>
-                                                    <option>4</option>
-                                                    <option>5</option>
-                                                </select>
-                                            </div>
-                                            <div class="form-group">
-                                                <label>Multiple Selects</label>
-                                                <select multiple class="form-control">
-                                                    <option>1</option>
-                                                    <option>2</option>
-                                                    <option>3</option>
-                                                    <option>4</option>
-                                                    <option>5</option>
-                                                </select>
-                                            </div>
-                                            <button type="submit" class="btn btn-default">Submit Button</button>
-                                            <button type="reset" class="btn btn-default">Reset Button</button>
-                                        </form>
-                                    </div>
-                                    <!-- /.col-lg-6 (nested) -->
-                                    <div class="col-lg-6">
-                                        <h1>Disabled Form States</h1>
-                                        <form role="form">
-                                            <fieldset disabled>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Basic Form Elements
+                                </div>
+                                <div class="panel-body">
+                                    <div class="row">
+                                        <div class="col-lg-6">
+                                            <form role="form">
                                                 <div class="form-group">
-                                                    <label for="disabledSelect">Disabled input</label>
-                                                    <input class="form-control" id="disabledInput" type="text" placeholder="Disabled input" disabled>
+                                                    <label>Text Input</label>
+                                                    <input class="form-control">
+                                                    <p class="help-block">Example block-level help text here.</p>
                                                 </div>
                                                 <div class="form-group">
-                                                    <label for="disabledSelect">Disabled select menu</label>
-                                                    <select id="disabledSelect" class="form-control">
-                                                        <option>Disabled select</option>
+                                                    <label>Text Input with Placeholder</label>
+                                                    <input class="form-control" placeholder="Enter text">
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Static Control</label>
+                                                    <p class="form-control-static">email@example.com</p>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>File input</label>
+                                                    <input type="file">
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Text area</label>
+                                                    <textarea class="form-control" rows="3"></textarea>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Checkboxes</label>
+                                                    <div class="checkbox">
+                                                        <label>
+                                                            <input type="checkbox" value="">Checkbox 1
+                                                        </label>
+                                                    </div>
+                                                    <div class="checkbox">
+                                                        <label>
+                                                            <input type="checkbox" value="">Checkbox 2
+                                                        </label>
+                                                    </div>
+                                                    <div class="checkbox">
+                                                        <label>
+                                                            <input type="checkbox" value="">Checkbox 3
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Inline Checkboxes</label>
+                                                    <label class="checkbox-inline">
+                                                        <input type="checkbox">1
+                                                    </label>
+                                                    <label class="checkbox-inline">
+                                                        <input type="checkbox">2
+                                                    </label>
+                                                    <label class="checkbox-inline">
+                                                        <input type="checkbox">3
+                                                    </label>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Radio Buttons</label>
+                                                    <div class="radio">
+                                                        <label>
+                                                            <input type="radio" name="optionsRadios" id="optionsRadios1" value="option1" checked>Radio 1
+                                                        </label>
+                                                    </div>
+                                                    <div class="radio">
+                                                        <label>
+                                                            <input type="radio" name="optionsRadios" id="optionsRadios2" value="option2">Radio 2
+                                                        </label>
+                                                    </div>
+                                                    <div class="radio">
+                                                        <label>
+                                                            <input type="radio" name="optionsRadios" id="optionsRadios3" value="option3">Radio 3
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Inline Radio Buttons</label>
+                                                    <label class="radio-inline">
+                                                        <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline1" value="option1" checked>1
+                                                    </label>
+                                                    <label class="radio-inline">
+                                                        <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline2" value="option2">2
+                                                    </label>
+                                                    <label class="radio-inline">
+                                                        <input type="radio" name="optionsRadiosInline" id="optionsRadiosInline3" value="option3">3
+                                                    </label>
+                                                </div>
+                                                <div class="form-group">
+                                                    <label>Selects</label>
+                                                    <select class="form-control">
+                                                        <option>1</option>
+                                                        <option>2</option>
+                                                        <option>3</option>
+                                                        <option>4</option>
+                                                        <option>5</option>
                                                     </select>
                                                 </div>
-                                                <div class="checkbox">
-                                                    <label>
-                                                        <input type="checkbox">Disabled Checkbox
-                                                    </label>
+                                                <div class="form-group">
+                                                    <label>Multiple Selects</label>
+                                                    <select multiple class="form-control">
+                                                        <option>1</option>
+                                                        <option>2</option>
+                                                        <option>3</option>
+                                                        <option>4</option>
+                                                        <option>5</option>
+                                                    </select>
                                                 </div>
-                                                <button type="submit" class="btn btn-primary">Disabled Button</button>
-                                            </fieldset>
-                                        </form>
-                                        <h1>Form Validation States</h1>
-                                        <form role="form">
-                                            <div class="form-group has-success">
-                                                <label class="control-label" for="inputSuccess">Input with success</label>
-                                                <input type="text" class="form-control" id="inputSuccess">
-                                            </div>
-                                            <div class="form-group has-warning">
-                                                <label class="control-label" for="inputWarning">Input with warning</label>
-                                                <input type="text" class="form-control" id="inputWarning">
-                                            </div>
-                                            <div class="form-group has-error">
-                                                <label class="control-label" for="inputError">Input with error</label>
-                                                <input type="text" class="form-control" id="inputError">
-                                            </div>
-                                        </form>
-                                        <h1>Input Groups</h1>
-                                        <form role="form">
-                                            <div class="form-group input-group">
-                                                <span class="input-group-addon">@</span>
-                                                <input type="text" class="form-control" placeholder="Username">
-                                            </div>
-                                            <div class="form-group input-group">
-                                                <input type="text" class="form-control">
-                                                <span class="input-group-addon">.00</span>
-                                            </div>
-                                            <div class="form-group input-group">
-                                                <span class="input-group-addon"><i class="fa fa-eur"></i>
-                                                </span>
-                                                <input type="text" class="form-control" placeholder="Font Awesome Icon">
-                                            </div>
-                                            <div class="form-group input-group">
-                                                <span class="input-group-addon">$</span>
-                                                <input type="text" class="form-control">
-                                                <span class="input-group-addon">.00</span>
-                                            </div>
-                                            <div class="form-group input-group">
-                                                <input type="text" class="form-control">
-                                                <span class="input-group-btn">
-                                                    <button class="btn btn-default" type="button"><i class="fa fa-search"></i>
-                                                    </button>
-                                                </span>
-                                            </div>
-                                        </form>
+                                                <button type="submit" class="btn btn-default">Submit Button</button>
+                                                <button type="reset" class="btn btn-default">Reset Button</button>
+                                            </form>
+                                        </div>
+                                        <!-- /.col-lg-6 (nested) -->
+                                        <div class="col-lg-6">
+                                            <h1>Disabled Form States</h1>
+                                            <form role="form">
+                                                <fieldset disabled>
+                                                    <div class="form-group">
+                                                        <label for="disabledSelect">Disabled input</label>
+                                                        <input class="form-control" id="disabledInput" type="text" placeholder="Disabled input" disabled>
+                                                    </div>
+                                                    <div class="form-group">
+                                                        <label for="disabledSelect">Disabled select menu</label>
+                                                        <select id="disabledSelect" class="form-control">
+                                                            <option>Disabled select</option>
+                                                        </select>
+                                                    </div>
+                                                    <div class="checkbox">
+                                                        <label>
+                                                            <input type="checkbox">Disabled Checkbox
+                                                        </label>
+                                                    </div>
+                                                    <button type="submit" class="btn btn-primary">Disabled Button</button>
+                                                </fieldset>
+                                            </form>
+                                            <h1>Form Validation States</h1>
+                                            <form role="form">
+                                                <div class="form-group has-success">
+                                                    <label class="control-label" for="inputSuccess">Input with success</label>
+                                                    <input type="text" class="form-control" id="inputSuccess">
+                                                </div>
+                                                <div class="form-group has-warning">
+                                                    <label class="control-label" for="inputWarning">Input with warning</label>
+                                                    <input type="text" class="form-control" id="inputWarning">
+                                                </div>
+                                                <div class="form-group has-error">
+                                                    <label class="control-label" for="inputError">Input with error</label>
+                                                    <input type="text" class="form-control" id="inputError">
+                                                </div>
+                                            </form>
+                                            <h1>Input Groups</h1>
+                                            <form role="form">
+                                                <div class="form-group input-group">
+                                                    <span class="input-group-addon">@</span>
+                                                    <input type="text" class="form-control" placeholder="Username">
+                                                </div>
+                                                <div class="form-group input-group">
+                                                    <input type="text" class="form-control">
+                                                    <span class="input-group-addon">.00</span>
+                                                </div>
+                                                <div class="form-group input-group">
+                                                    <span class="input-group-addon"><i class="fa fa-eur"></i>
+                                                    </span>
+                                                    <input type="text" class="form-control" placeholder="Font Awesome Icon">
+                                                </div>
+                                                <div class="form-group input-group">
+                                                    <span class="input-group-addon">$</span>
+                                                    <input type="text" class="form-control">
+                                                    <span class="input-group-addon">.00</span>
+                                                </div>
+                                                <div class="form-group input-group">
+                                                    <input type="text" class="form-control">
+                                                    <span class="input-group-btn">
+                                                        <button class="btn btn-default" type="button"><i class="fa fa-search"></i>
+                                                        </button>
+                                                    </span>
+                                                </div>
+                                            </form>
+                                        </div>
+                                        <!-- /.col-lg-6 (nested) -->
                                     </div>
-                                    <!-- /.col-lg-6 (nested) -->
+                                    <!-- /.row (nested) -->
                                 </div>
-                                <!-- /.row (nested) -->
+                                <!-- /.panel-body -->
                             </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/grid.html
+++ b/pages/grid.html
@@ -230,308 +230,310 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Grid</h1>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3>Grid options</h3>
-                                <p>See how aspects of the Bootstrap grid system work across multiple devices with a handy table.</p>
-                                <div class="table-responsive">
-                                    <table class="table table-bordered table-striped">
-                                        <thead>
-                                            <tr>
-                                                <th></th>
-                                                <th>
-                                                    Extra small devices
-                                                    <small>Phones (&lt;768px)</small>
-                                                </th>
-                                                <th>
-                                                    Small devices
-                                                    <small>Tablets (&ge;768px)</small>
-                                                </th>
-                                                <th>
-                                                    Medium devices
-                                                    <small>Desktops (&ge;992px)</small>
-                                                </th>
-                                                <th>
-                                                    Large devices
-                                                    <small>Desktops (&ge;1200px)</small>
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <th>Grid behavior</th>
-                                                <td>Horizontal at all times</td>
-                                                <td colspan="3">Collapsed to start, horizontal above breakpoints</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Max container width</th>
-                                                <td>None (auto)</td>
-                                                <td>750px</td>
-                                                <td>970px</td>
-                                                <td>1170px</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Class prefix</th>
-                                                <td>
-                                                    <code>.col-xs-</code>
-                                                </td>
-                                                <td>
-                                                    <code>.col-sm-</code>
-                                                </td>
-                                                <td>
-                                                    <code>.col-md-</code>
-                                                </td>
-                                                <td>
-                                                    <code>.col-lg-</code>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <th># of columns</th>
-                                                <td colspan="4">12</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Max column width</th>
-                                                <td class="text-muted">Auto</td>
-                                                <td>60px</td>
-                                                <td>78px</td>
-                                                <td>95px</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Gutter width</th>
-                                                <td colspan="4">30px (15px on each side of a column)</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Nestable</th>
-                                                <td colspan="4">Yes</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Offsets</th>
-                                                <td colspan="4">Yes</td>
-                                            </tr>
-                                            <tr>
-                                                <th>Column ordering</th>
-                                                <td colspan="4">Yes</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <p>Grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes, and override grid classes targeted at smaller devices. Therefore, applying any
-                                    <code>.col-md-</code> class to an element will not only affect its styling on medium devices but also on large devices if a
-                                    <code>.col-lg-</code> class is not present.</p>
-                            </div>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Grid</h1>
                         </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3>Example: Stacked-to-horizontal</h3>
-                                <p>Using a single set of
-                                    <code>.col-md-*</code> grid classes, you can create a default grid system that starts out stacked on mobile devices and tablet devices (the extra small to small range) before becoming horizontal on desktop (medium) devices. Place grid columns in any
-                                    <code>.row</code>.</p>
-                                <div class="row show-grid">
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                    <div class="col-md-1">.col-md-1</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-md-8">.col-md-8</div>
-                                    <div class="col-md-4">.col-md-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-md-4">.col-md-4</div>
-                                    <div class="col-md-4">.col-md-4</div>
-                                    <div class="col-md-4">.col-md-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-md-6">.col-md-6</div>
-                                    <div class="col-md-6">.col-md-6</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3>Example: Mobile and desktop</h3>
-                                <p>Don't want your columns to simply stack in smaller devices? Use the extra small and medium device grid classes by adding
-                                    <code>.col-xs-*</code>
-                                    <code>.col-md-*</code> to your columns. See the example below for a better idea of how it all works.</p>
-                                <div class="row show-grid">
-                                    <div class="col-xs-12 col-md-8">.col-xs-12 .col-md-8</div>
-                                    <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
-                                    <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
-                                    <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-xs-6">.col-xs-6</div>
-                                    <div class="col-xs-6">.col-xs-6</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3>Example: Mobile, tablet, desktops</h3>
-                                <p>Build on the previous example by creating even more dynamic and powerful layouts with tablet
-                                    <code>.col-sm-*</code> classes.</p>
-                                <div class="row show-grid">
-                                    <div class="col-xs-12 col-sm-6 col-md-8">.col-xs-12 .col-sm-6 .col-md-8</div>
-                                    <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
-                                    <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
-                                    <!-- Optional: clear the XS cols if their content doesn't match in height -->
-                                    <div class="clearfix visible-xs"></div>
-                                    <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3 id="grid-responsive-resets">Responsive column resets</h3>
-                                <p>With the four tiers of grids available you're bound to run into issues where, at certain breakpoints, your columns don't clear quite right as one is taller than the other. To fix that, use a combination of a
-                                    <code>.clearfix</code> and our <a href="#responsive-utilities">responsive utility classes</a>.</p>
-                                <div class="row show-grid">
-                                    <div class="col-xs-6 col-sm-3">
-                                        .col-xs-6 .col-sm-3
-                                        <br>Resize your viewport or check it out on your phone for an example.
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3>Grid options</h3>
+                                    <p>See how aspects of the Bootstrap grid system work across multiple devices with a handy table.</p>
+                                    <div class="table-responsive">
+                                        <table class="table table-bordered table-striped">
+                                            <thead>
+                                                <tr>
+                                                    <th></th>
+                                                    <th>
+                                                        Extra small devices
+                                                        <small>Phones (&lt;768px)</small>
+                                                    </th>
+                                                    <th>
+                                                        Small devices
+                                                        <small>Tablets (&ge;768px)</small>
+                                                    </th>
+                                                    <th>
+                                                        Medium devices
+                                                        <small>Desktops (&ge;992px)</small>
+                                                    </th>
+                                                    <th>
+                                                        Large devices
+                                                        <small>Desktops (&ge;1200px)</small>
+                                                    </th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <th>Grid behavior</th>
+                                                    <td>Horizontal at all times</td>
+                                                    <td colspan="3">Collapsed to start, horizontal above breakpoints</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Max container width</th>
+                                                    <td>None (auto)</td>
+                                                    <td>750px</td>
+                                                    <td>970px</td>
+                                                    <td>1170px</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Class prefix</th>
+                                                    <td>
+                                                        <code>.col-xs-</code>
+                                                    </td>
+                                                    <td>
+                                                        <code>.col-sm-</code>
+                                                    </td>
+                                                    <td>
+                                                        <code>.col-md-</code>
+                                                    </td>
+                                                    <td>
+                                                        <code>.col-lg-</code>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <th># of columns</th>
+                                                    <td colspan="4">12</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Max column width</th>
+                                                    <td class="text-muted">Auto</td>
+                                                    <td>60px</td>
+                                                    <td>78px</td>
+                                                    <td>95px</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Gutter width</th>
+                                                    <td colspan="4">30px (15px on each side of a column)</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Nestable</th>
+                                                    <td colspan="4">Yes</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Offsets</th>
+                                                    <td colspan="4">Yes</td>
+                                                </tr>
+                                                <tr>
+                                                    <th>Column ordering</th>
+                                                    <td colspan="4">Yes</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
                                     </div>
-                                    <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
-
-                                    <!-- Add the extra clearfix for only the required viewport -->
-                                    <div class="clearfix visible-xs"></div>
-
-                                    <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
-                                    <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
+                                    <p>Grid classes apply to devices with screen widths greater than or equal to the breakpoint sizes, and override grid classes targeted at smaller devices. Therefore, applying any
+                                        <code>.col-md-</code> class to an element will not only affect its styling on medium devices but also on large devices if a
+                                        <code>.col-lg-</code> class is not present.</p>
                                 </div>
                             </div>
                         </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
+                    <!-- /.row -->
 
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3 id="grid-offsetting">Offsetting columns</h3>
-                                <p>Move columns to the right using
-                                    <code>.col-md-offset-*</code> classes. These classes increase the left margin of a column by
-                                    <code>*</code> columns. For example,
-                                    <code>.col-md-offset-4</code> moves
-                                    <code>.col-md-4</code> over four columns.</p>
-                                <div class="row show-grid">
-                                    <div class="col-md-4">.col-md-4</div>
-                                    <div class="col-md-4 col-md-offset-4">.col-md-4 .col-md-offset-4</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
-                                    <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
-                                </div>
-                                <div class="row show-grid">
-                                    <div class="col-md-6 col-md-offset-3">.col-md-6 .col-md-offset-3</div>
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3>Example: Stacked-to-horizontal</h3>
+                                    <p>Using a single set of
+                                        <code>.col-md-*</code> grid classes, you can create a default grid system that starts out stacked on mobile devices and tablet devices (the extra small to small range) before becoming horizontal on desktop (medium) devices. Place grid columns in any
+                                        <code>.row</code>.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                        <div class="col-md-1">.col-md-1</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-md-8">.col-md-8</div>
+                                        <div class="col-md-4">.col-md-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-md-4">.col-md-4</div>
+                                        <div class="col-md-4">.col-md-4</div>
+                                        <div class="col-md-4">.col-md-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-md-6">.col-md-6</div>
+                                        <div class="col-md-6">.col-md-6</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
+                    <!-- /.row -->
 
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3 id="grid-nesting">Nesting columns</h3>
-                                <p>To nest your content with the default grid, add a new
-                                    <code>.row</code> and set of
-                                    <code>.col-md-*</code> columns within an existing
-                                    <code>.col-md-*</code> column. Nested rows should include a set of columns that add up to 12.</p>
-                                <div class="row show-grid">
-                                    <div class="col-md-9">
-                                        Level 1: .col-md-9
-                                        <div class="row show-grid">
-                                            <div class="col-md-6">
-                                                Level 2: .col-md-6
-                                            </div>
-                                            <div class="col-md-6">
-                                                Level 2: .col-md-6
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3>Example: Mobile and desktop</h3>
+                                    <p>Don't want your columns to simply stack in smaller devices? Use the extra small and medium device grid classes by adding
+                                        <code>.col-xs-*</code>
+                                        <code>.col-md-*</code> to your columns. See the example below for a better idea of how it all works.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-12 col-md-8">.col-xs-12 .col-md-8</div>
+                                        <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
+                                        <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
+                                        <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-6">.col-xs-6</div>
+                                        <div class="col-xs-6">.col-xs-6</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
+
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3>Example: Mobile, tablet, desktops</h3>
+                                    <p>Build on the previous example by creating even more dynamic and powerful layouts with tablet
+                                        <code>.col-sm-*</code> classes.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-12 col-sm-6 col-md-8">.col-xs-12 .col-sm-6 .col-md-8</div>
+                                        <div class="col-xs-6 col-md-4">.col-xs-6 .col-md-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
+                                        <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
+                                        <!-- Optional: clear the XS cols if their content doesn't match in height -->
+                                        <div class="clearfix visible-xs"></div>
+                                        <div class="col-xs-6 col-sm-4">.col-xs-6 .col-sm-4</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
+
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3 id="grid-responsive-resets">Responsive column resets</h3>
+                                    <p>With the four tiers of grids available you're bound to run into issues where, at certain breakpoints, your columns don't clear quite right as one is taller than the other. To fix that, use a combination of a
+                                        <code>.clearfix</code> and our <a href="#responsive-utilities">responsive utility classes</a>.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-xs-6 col-sm-3">
+                                            .col-xs-6 .col-sm-3
+                                            <br>Resize your viewport or check it out on your phone for an example.
+                                        </div>
+                                        <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
+
+                                        <!-- Add the extra clearfix for only the required viewport -->
+                                        <div class="clearfix visible-xs"></div>
+
+                                        <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
+                                        <div class="col-xs-6 col-sm-3">.col-xs-6 .col-sm-3</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
+
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3 id="grid-offsetting">Offsetting columns</h3>
+                                    <p>Move columns to the right using
+                                        <code>.col-md-offset-*</code> classes. These classes increase the left margin of a column by
+                                        <code>*</code> columns. For example,
+                                        <code>.col-md-offset-4</code> moves
+                                        <code>.col-md-4</code> over four columns.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-md-4">.col-md-4</div>
+                                        <div class="col-md-4 col-md-offset-4">.col-md-4 .col-md-offset-4</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
+                                        <div class="col-md-3 col-md-offset-3">.col-md-3 .col-md-offset-3</div>
+                                    </div>
+                                    <div class="row show-grid">
+                                        <div class="col-md-6 col-md-offset-3">.col-md-6 .col-md-offset-3</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
+
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3 id="grid-nesting">Nesting columns</h3>
+                                    <p>To nest your content with the default grid, add a new
+                                        <code>.row</code> and set of
+                                        <code>.col-md-*</code> columns within an existing
+                                        <code>.col-md-*</code> column. Nested rows should include a set of columns that add up to 12.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-md-9">
+                                            Level 1: .col-md-9
+                                            <div class="row show-grid">
+                                                <div class="col-md-6">
+                                                    Level 2: .col-md-6
+                                                </div>
+                                                <div class="col-md-6">
+                                                    Level 2: .col-md-6
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
+                    <!-- /.row -->
 
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-body">
-                                <h3 id="grid-column-ordering">Column ordering</h3>
-                                <p>Easily change the order of our built-in grid columns with
-                                    <code>.col-md-push-*</code> and
-                                    <code>.col-md-pull-*</code> modifier classes.</p>
-                                <div class="row show-grid">
-                                    <div class="col-md-9 col-md-push-3">.col-md-9 .col-md-push-3</div>
-                                    <div class="col-md-3 col-md-pull-9">.col-md-3 .col-md-pull-9</div>
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-body">
+                                    <h3 id="grid-column-ordering">Column ordering</h3>
+                                    <p>Easily change the order of our built-in grid columns with
+                                        <code>.col-md-push-*</code> and
+                                        <code>.col-md-pull-*</code> modifier classes.</p>
+                                    <div class="row show-grid">
+                                        <div class="col-md-9 col-md-push-3">.col-md-9 .col-md-push-3</div>
+                                        <div class="col-md-3 col-md-pull-9">.col-md-3 .col-md-pull-9</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/icons.html
+++ b/pages/icons.html
@@ -230,5052 +230,5054 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Icons</h1>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                All available icons
-                            </div>
-                            <div class="panel-body">
-
-                                <div class="row">
-
-
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use 500px">&#xf26e</i>
-                                        fa-500px
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use adjust">&#xf042</i>
-                                        fa-adjust
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use adn">&#xf170</i>
-                                        fa-adn
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-center">&#xf037</i>
-                                        fa-align-center
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-justify">&#xf039</i>
-                                        fa-align-justify
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-left">&#xf036</i>
-                                        fa-align-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-right">&#xf038</i>
-                                        fa-align-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use amazon">&#xf270</i>
-                                        fa-amazon
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ambulance">&#xf0f9</i>
-                                        fa-ambulance
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use american-sign-language-interpreting">&#xf2a3</i>
-                                        fa-american-sign-language-interpreting
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use anchor">&#xf13d</i>
-                                        fa-anchor
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use android">&#xf17b</i>
-                                        fa-android
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angellist">&#xf209</i>
-                                        fa-angellist
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-down">&#xf103</i>
-                                        fa-angle-double-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-left">&#xf100</i>
-                                        fa-angle-double-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-right">&#xf101</i>
-                                        fa-angle-double-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-up">&#xf102</i>
-                                        fa-angle-double-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-down">&#xf107</i>
-                                        fa-angle-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-left">&#xf104</i>
-                                        fa-angle-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-right">&#xf105</i>
-                                        fa-angle-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-up">&#xf106</i>
-                                        fa-angle-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use apple">&#xf179</i>
-                                        fa-apple
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use archive">&#xf187</i>
-                                        fa-archive
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use area-chart">&#xf1fe</i>
-                                        fa-area-chart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-down">&#xf0ab</i>
-                                        fa-arrow-circle-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-left">&#xf0a8</i>
-                                        fa-arrow-circle-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-down">&#xf01a</i>
-                                        fa-arrow-circle-o-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-left">&#xf190</i>
-                                        fa-arrow-circle-o-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-right">&#xf18e</i>
-                                        fa-arrow-circle-o-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-up">&#xf01b</i>
-                                        fa-arrow-circle-o-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-right">&#xf0a9</i>
-                                        fa-arrow-circle-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-up">&#xf0aa</i>
-                                        fa-arrow-circle-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-down">&#xf063</i>
-                                        fa-arrow-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-left">&#xf060</i>
-                                        fa-arrow-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-right">&#xf061</i>
-                                        fa-arrow-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-up">&#xf062</i>
-                                        fa-arrow-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows">&#xf047</i>
-                                        fa-arrows
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-alt">&#xf0b2</i>
-                                        fa-arrows-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-h">&#xf07e</i>
-                                        fa-arrows-h
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-v">&#xf07d</i>
-                                        fa-arrows-v
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use asl-interpreting">&#xf2a3</i>
-                                        fa-asl-interpreting
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use assistive-listening-systems">&#xf2a2</i>
-                                        fa-assistive-listening-systems
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use asterisk">&#xf069</i>
-                                        fa-asterisk
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use at">&#xf1fa</i>
-                                        fa-at
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use audio-description">&#xf29e</i>
-                                        fa-audio-description
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use automobile">&#xf1b9</i>
-                                        fa-automobile
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use backward">&#xf04a</i>
-                                        fa-backward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use balance-scale">&#xf24e</i>
-                                        fa-balance-scale
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ban">&#xf05e</i>
-                                        fa-ban
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bank">&#xf19c</i>
-                                        fa-bank
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bar-chart">&#xf080</i>
-                                        fa-bar-chart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bar-chart-o">&#xf080</i>
-                                        fa-bar-chart-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use barcode">&#xf02a</i>
-                                        fa-barcode
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bars">&#xf0c9</i>
-                                        fa-bars
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-0">&#xf244</i>
-                                        fa-battery-0
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-1">&#xf243</i>
-                                        fa-battery-1
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-2">&#xf242</i>
-                                        fa-battery-2
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-3">&#xf241</i>
-                                        fa-battery-3
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-4">&#xf240</i>
-                                        fa-battery-4
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-empty">&#xf244</i>
-                                        fa-battery-empty
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-full">&#xf240</i>
-                                        fa-battery-full
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-half">&#xf242</i>
-                                        fa-battery-half
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-quarter">&#xf243</i>
-                                        fa-battery-quarter
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-three-quarters">&#xf241</i>
-                                        fa-battery-three-quarters
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bed">&#xf236</i>
-                                        fa-bed
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use beer">&#xf0fc</i>
-                                        fa-beer
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use behance">&#xf1b4</i>
-                                        fa-behance
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use behance-square">&#xf1b5</i>
-                                        fa-behance-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell">&#xf0f3</i>
-                                        fa-bell
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-o">&#xf0a2</i>
-                                        fa-bell-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-slash">&#xf1f6</i>
-                                        fa-bell-slash
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-slash-o">&#xf1f7</i>
-                                        fa-bell-slash-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bicycle">&#xf206</i>
-                                        fa-bicycle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use binoculars">&#xf1e5</i>
-                                        fa-binoculars
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use birthday-cake">&#xf1fd</i>
-                                        fa-birthday-cake
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitbucket">&#xf171</i>
-                                        fa-bitbucket
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitbucket-square">&#xf172</i>
-                                        fa-bitbucket-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitcoin">&#xf15a</i>
-                                        fa-bitcoin
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use black-tie">&#xf27e</i>
-                                        fa-black-tie
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use blind">&#xf29d</i>
-                                        fa-blind
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bluetooth">&#xf293</i>
-                                        fa-bluetooth
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bluetooth-b">&#xf294</i>
-                                        fa-bluetooth-b
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bold">&#xf032</i>
-                                        fa-bold
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bolt">&#xf0e7</i>
-                                        fa-bolt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bomb">&#xf1e2</i>
-                                        fa-bomb
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use book">&#xf02d</i>
-                                        fa-book
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bookmark">&#xf02e</i>
-                                        fa-bookmark
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bookmark-o">&#xf097</i>
-                                        fa-bookmark-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use braille">&#xf2a1</i>
-                                        fa-braille
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use briefcase">&#xf0b1</i>
-                                        fa-briefcase
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use btc">&#xf15a</i>
-                                        fa-btc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bug">&#xf188</i>
-                                        fa-bug
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use building">&#xf1ad</i>
-                                        fa-building
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use building-o">&#xf0f7</i>
-                                        fa-building-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bullhorn">&#xf0a1</i>
-                                        fa-bullhorn
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bullseye">&#xf140</i>
-                                        fa-bullseye
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use bus">&#xf207</i>
-                                        fa-bus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use buysellads">&#xf20d</i>
-                                        fa-buysellads
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cab">&#xf1ba</i>
-                                        fa-cab
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calculator">&#xf1ec</i>
-                                        fa-calculator
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar">&#xf073</i>
-                                        fa-calendar
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-check-o">&#xf274</i>
-                                        fa-calendar-check-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-minus-o">&#xf272</i>
-                                        fa-calendar-minus-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-o">&#xf133</i>
-                                        fa-calendar-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-plus-o">&#xf271</i>
-                                        fa-calendar-plus-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-times-o">&#xf273</i>
-                                        fa-calendar-times-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use camera">&#xf030</i>
-                                        fa-camera
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use camera-retro">&#xf083</i>
-                                        fa-camera-retro
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use car">&#xf1b9</i>
-                                        fa-car
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-down">&#xf0d7</i>
-                                        fa-caret-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-left">&#xf0d9</i>
-                                        fa-caret-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-right">&#xf0da</i>
-                                        fa-caret-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-down">&#xf150</i>
-                                        fa-caret-square-o-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-left">&#xf191</i>
-                                        fa-caret-square-o-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-right">&#xf152</i>
-                                        fa-caret-square-o-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-up">&#xf151</i>
-                                        fa-caret-square-o-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-up">&#xf0d8</i>
-                                        fa-caret-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cart-arrow-down">&#xf218</i>
-                                        fa-cart-arrow-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cart-plus">&#xf217</i>
-                                        fa-cart-plus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc">&#xf20a</i>
-                                        fa-cc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-amex">&#xf1f3</i>
-                                        fa-cc-amex
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-diners-club">&#xf24c</i>
-                                        fa-cc-diners-club
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-discover">&#xf1f2</i>
-                                        fa-cc-discover
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-jcb">&#xf24b</i>
-                                        fa-cc-jcb
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-mastercard">&#xf1f1</i>
-                                        fa-cc-mastercard
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-paypal">&#xf1f4</i>
-                                        fa-cc-paypal
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-stripe">&#xf1f5</i>
-                                        fa-cc-stripe
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-visa">&#xf1f0</i>
-                                        fa-cc-visa
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use certificate">&#xf0a3</i>
-                                        fa-certificate
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chain">&#xf0c1</i>
-                                        fa-chain
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chain-broken">&#xf127</i>
-                                        fa-chain-broken
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use check">&#xf00c</i>
-                                        fa-check
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-circle">&#xf058</i>
-                                        fa-check-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-circle-o">&#xf05d</i>
-                                        fa-check-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-square">&#xf14a</i>
-                                        fa-check-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-square-o">&#xf046</i>
-                                        fa-check-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-down">&#xf13a</i>
-                                        fa-chevron-circle-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-left">&#xf137</i>
-                                        fa-chevron-circle-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-right">&#xf138</i>
-                                        fa-chevron-circle-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-up">&#xf139</i>
-                                        fa-chevron-circle-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-down">&#xf078</i>
-                                        fa-chevron-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-left">&#xf053</i>
-                                        fa-chevron-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-right">&#xf054</i>
-                                        fa-chevron-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-up">&#xf077</i>
-                                        fa-chevron-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use child">&#xf1ae</i>
-                                        fa-child
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use chrome">&#xf268</i>
-                                        fa-chrome
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle">&#xf111</i>
-                                        fa-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-o">&#xf10c</i>
-                                        fa-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-o-notch">&#xf1ce</i>
-                                        fa-circle-o-notch
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-thin">&#xf1db</i>
-                                        fa-circle-thin
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use clipboard">&#xf0ea</i>
-                                        fa-clipboard
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use clock-o">&#xf017</i>
-                                        fa-clock-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use clone">&#xf24d</i>
-                                        fa-clone
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use close">&#xf00d</i>
-                                        fa-close
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud">&#xf0c2</i>
-                                        fa-cloud
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud-download">&#xf0ed</i>
-                                        fa-cloud-download
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud-upload">&#xf0ee</i>
-                                        fa-cloud-upload
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cny">&#xf157</i>
-                                        fa-cny
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use code">&#xf121</i>
-                                        fa-code
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use code-fork">&#xf126</i>
-                                        fa-code-fork
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use codepen">&#xf1cb</i>
-                                        fa-codepen
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use codiepie">&#xf284</i>
-                                        fa-codiepie
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use coffee">&#xf0f4</i>
-                                        fa-coffee
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cog">&#xf013</i>
-                                        fa-cog
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cogs">&#xf085</i>
-                                        fa-cogs
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use columns">&#xf0db</i>
-                                        fa-columns
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use comment">&#xf075</i>
-                                        fa-comment
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use comment-o">&#xf0e5</i>
-                                        fa-comment-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use commenting">&#xf27a</i>
-                                        fa-commenting
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use commenting-o">&#xf27b</i>
-                                        fa-commenting-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use comments">&#xf086</i>
-                                        fa-comments
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use comments-o">&#xf0e6</i>
-                                        fa-comments-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use compass">&#xf14e</i>
-                                        fa-compass
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use compress">&#xf066</i>
-                                        fa-compress
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use connectdevelop">&#xf20e</i>
-                                        fa-connectdevelop
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use contao">&#xf26d</i>
-                                        fa-contao
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use copy">&#xf0c5</i>
-                                        fa-copy
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use copyright">&#xf1f9</i>
-                                        fa-copyright
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use creative-commons">&#xf25e</i>
-                                        fa-creative-commons
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use credit-card">&#xf09d</i>
-                                        fa-credit-card
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use credit-card-alt">&#xf283</i>
-                                        fa-credit-card-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use crop">&#xf125</i>
-                                        fa-crop
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use crosshairs">&#xf05b</i>
-                                        fa-crosshairs
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use css3">&#xf13c</i>
-                                        fa-css3
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cube">&#xf1b2</i>
-                                        fa-cube
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cubes">&#xf1b3</i>
-                                        fa-cubes
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cut">&#xf0c4</i>
-                                        fa-cut
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use cutlery">&#xf0f5</i>
-                                        fa-cutlery
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dashboard">&#xf0e4</i>
-                                        fa-dashboard
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dashcube">&#xf210</i>
-                                        fa-dashcube
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use database">&#xf1c0</i>
-                                        fa-database
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use deaf">&#xf2a4</i>
-                                        fa-deaf
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use deafness">&#xf2a4</i>
-                                        fa-deafness
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dedent">&#xf03b</i>
-                                        fa-dedent
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use delicious">&#xf1a5</i>
-                                        fa-delicious
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use desktop">&#xf108</i>
-                                        fa-desktop
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use deviantart">&#xf1bd</i>
-                                        fa-deviantart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use diamond">&#xf219</i>
-                                        fa-diamond
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use digg">&#xf1a6</i>
-                                        fa-digg
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dollar">&#xf155</i>
-                                        fa-dollar
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dot-circle-o">&#xf192</i>
-                                        fa-dot-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use download">&#xf019</i>
-                                        fa-download
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dribbble">&#xf17d</i>
-                                        fa-dribbble
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use dropbox">&#xf16b</i>
-                                        fa-dropbox
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use drupal">&#xf1a9</i>
-                                        fa-drupal
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use edge">&#xf282</i>
-                                        fa-edge
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use edit">&#xf044</i>
-                                        fa-edit
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eject">&#xf052</i>
-                                        fa-eject
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ellipsis-h">&#xf141</i>
-                                        fa-ellipsis-h
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ellipsis-v">&#xf142</i>
-                                        fa-ellipsis-v
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use empire">&#xf1d1</i>
-                                        fa-empire
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope">&#xf0e0</i>
-                                        fa-envelope
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope-o">&#xf003</i>
-                                        fa-envelope-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope-square">&#xf199</i>
-                                        fa-envelope-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use envira">&#xf299</i>
-                                        fa-envira
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eraser">&#xf12d</i>
-                                        fa-eraser
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eur">&#xf153</i>
-                                        fa-eur
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use euro">&#xf153</i>
-                                        fa-euro
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use exchange">&#xf0ec</i>
-                                        fa-exchange
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation">&#xf12a</i>
-                                        fa-exclamation
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation-circle">&#xf06a</i>
-                                        fa-exclamation-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation-triangle">&#xf071</i>
-                                        fa-exclamation-triangle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use expand">&#xf065</i>
-                                        fa-expand
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use expeditedssl">&#xf23e</i>
-                                        fa-expeditedssl
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use external-link">&#xf08e</i>
-                                        fa-external-link
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use external-link-square">&#xf14c</i>
-                                        fa-external-link-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eye">&#xf06e</i>
-                                        fa-eye
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eye-slash">&#xf070</i>
-                                        fa-eye-slash
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use eyedropper">&#xf1fb</i>
-                                        fa-eyedropper
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fa">&#xf2b4</i>
-                                        fa-fa
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook">&#xf09a</i>
-                                        fa-facebook
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-f">&#xf09a</i>
-                                        fa-facebook-f
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-official">&#xf230</i>
-                                        fa-facebook-official
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-square">&#xf082</i>
-                                        fa-facebook-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fast-backward">&#xf049</i>
-                                        fa-fast-backward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fast-forward">&#xf050</i>
-                                        fa-fast-forward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fax">&#xf1ac</i>
-                                        fa-fax
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use feed">&#xf09e</i>
-                                        fa-feed
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use female">&#xf182</i>
-                                        fa-female
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fighter-jet">&#xf0fb</i>
-                                        fa-fighter-jet
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file">&#xf15b</i>
-                                        fa-file
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-archive-o">&#xf1c6</i>
-                                        fa-file-archive-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-audio-o">&#xf1c7</i>
-                                        fa-file-audio-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-code-o">&#xf1c9</i>
-                                        fa-file-code-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-excel-o">&#xf1c3</i>
-                                        fa-file-excel-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-image-o">&#xf1c5</i>
-                                        fa-file-image-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-movie-o">&#xf1c8</i>
-                                        fa-file-movie-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-o">&#xf016</i>
-                                        fa-file-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-pdf-o">&#xf1c1</i>
-                                        fa-file-pdf-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-photo-o">&#xf1c5</i>
-                                        fa-file-photo-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-picture-o">&#xf1c5</i>
-                                        fa-file-picture-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-powerpoint-o">&#xf1c4</i>
-                                        fa-file-powerpoint-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-sound-o">&#xf1c7</i>
-                                        fa-file-sound-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-text">&#xf15c</i>
-                                        fa-file-text
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-text-o">&#xf0f6</i>
-                                        fa-file-text-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-video-o">&#xf1c8</i>
-                                        fa-file-video-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-word-o">&#xf1c2</i>
-                                        fa-file-word-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-zip-o">&#xf1c6</i>
-                                        fa-file-zip-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use files-o">&#xf0c5</i>
-                                        fa-files-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use film">&#xf008</i>
-                                        fa-film
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use filter">&#xf0b0</i>
-                                        fa-filter
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fire">&#xf06d</i>
-                                        fa-fire
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fire-extinguisher">&#xf134</i>
-                                        fa-fire-extinguisher
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use firefox">&#xf269</i>
-                                        fa-firefox
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use first-order">&#xf2b0</i>
-                                        fa-first-order
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag">&#xf024</i>
-                                        fa-flag
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag-checkered">&#xf11e</i>
-                                        fa-flag-checkered
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag-o">&#xf11d</i>
-                                        fa-flag-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flash">&#xf0e7</i>
-                                        fa-flash
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flask">&#xf0c3</i>
-                                        fa-flask
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use flickr">&#xf16e</i>
-                                        fa-flickr
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use floppy-o">&#xf0c7</i>
-                                        fa-floppy-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder">&#xf07b</i>
-                                        fa-folder
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-o">&#xf114</i>
-                                        fa-folder-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-open">&#xf07c</i>
-                                        fa-folder-open
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-open-o">&#xf115</i>
-                                        fa-folder-open-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use font">&#xf031</i>
-                                        fa-font
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use font-awesome">&#xf2b4</i>
-                                        fa-font-awesome
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fonticons">&#xf280</i>
-                                        fa-fonticons
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use fort-awesome">&#xf286</i>
-                                        fa-fort-awesome
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use forumbee">&#xf211</i>
-                                        fa-forumbee
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use forward">&#xf04e</i>
-                                        fa-forward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use foursquare">&#xf180</i>
-                                        fa-foursquare
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use frown-o">&#xf119</i>
-                                        fa-frown-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use futbol-o">&#xf1e3</i>
-                                        fa-futbol-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gamepad">&#xf11b</i>
-                                        fa-gamepad
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gavel">&#xf0e3</i>
-                                        fa-gavel
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gbp">&#xf154</i>
-                                        fa-gbp
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ge">&#xf1d1</i>
-                                        fa-ge
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gear">&#xf013</i>
-                                        fa-gear
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gears">&#xf085</i>
-                                        fa-gears
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use genderless">&#xf22d</i>
-                                        fa-genderless
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use get-pocket">&#xf265</i>
-                                        fa-get-pocket
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gg">&#xf260</i>
-                                        fa-gg
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gg-circle">&#xf261</i>
-                                        fa-gg-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gift">&#xf06b</i>
-                                        fa-gift
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use git">&#xf1d3</i>
-                                        fa-git
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use git-square">&#xf1d2</i>
-                                        fa-git-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use github">&#xf09b</i>
-                                        fa-github
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use github-alt">&#xf113</i>
-                                        fa-github-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use github-square">&#xf092</i>
-                                        fa-github-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gitlab">&#xf296</i>
-                                        fa-gitlab
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gittip">&#xf184</i>
-                                        fa-gittip
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use glass">&#xf000</i>
-                                        fa-glass
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use glide">&#xf2a5</i>
-                                        fa-glide
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use glide-g">&#xf2a6</i>
-                                        fa-glide-g
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use globe">&#xf0ac</i>
-                                        fa-globe
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google">&#xf1a0</i>
-                                        fa-google
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus">&#xf0d5</i>
-                                        fa-google-plus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-circle">&#xf2b3</i>
-                                        fa-google-plus-circle
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-official">&#xf2b3</i>
-                                        fa-google-plus-official
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-square">&#xf0d4</i>
-                                        fa-google-plus-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-wallet">&#xf1ee</i>
-                                        fa-google-wallet
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use graduation-cap">&#xf19d</i>
-                                        fa-graduation-cap
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use gratipay">&#xf184</i>
-                                        fa-gratipay
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use group">&#xf0c0</i>
-                                        fa-group
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use h-square">&#xf0fd</i>
-                                        fa-h-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hacker-news">&#xf1d4</i>
-                                        fa-hacker-news
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-grab-o">&#xf255</i>
-                                        fa-hand-grab-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-lizard-o">&#xf258</i>
-                                        fa-hand-lizard-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-down">&#xf0a7</i>
-                                        fa-hand-o-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-left">&#xf0a5</i>
-                                        fa-hand-o-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-right">&#xf0a4</i>
-                                        fa-hand-o-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-up">&#xf0a6</i>
-                                        fa-hand-o-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-paper-o">&#xf256</i>
-                                        fa-hand-paper-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-peace-o">&#xf25b</i>
-                                        fa-hand-peace-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-pointer-o">&#xf25a</i>
-                                        fa-hand-pointer-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-rock-o">&#xf255</i>
-                                        fa-hand-rock-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-scissors-o">&#xf257</i>
-                                        fa-hand-scissors-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-spock-o">&#xf259</i>
-                                        fa-hand-spock-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-stop-o">&#xf256</i>
-                                        fa-hand-stop-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hard-of-hearing">&#xf2a4</i>
-                                        fa-hard-of-hearing
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hashtag">&#xf292</i>
-                                        fa-hashtag
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hdd-o">&#xf0a0</i>
-                                        fa-hdd-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use header">&#xf1dc</i>
-                                        fa-header
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use headphones">&#xf025</i>
-                                        fa-headphones
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use heart">&#xf004</i>
-                                        fa-heart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use heart-o">&#xf08a</i>
-                                        fa-heart-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use heartbeat">&#xf21e</i>
-                                        fa-heartbeat
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use history">&#xf1da</i>
-                                        fa-history
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use home">&#xf015</i>
-                                        fa-home
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hospital-o">&#xf0f8</i>
-                                        fa-hospital-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hotel">&#xf236</i>
-                                        fa-hotel
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass">&#xf254</i>
-                                        fa-hourglass
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-1">&#xf251</i>
-                                        fa-hourglass-1
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-2">&#xf252</i>
-                                        fa-hourglass-2
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-3">&#xf253</i>
-                                        fa-hourglass-3
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-end">&#xf253</i>
-                                        fa-hourglass-end
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-half">&#xf252</i>
-                                        fa-hourglass-half
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-o">&#xf250</i>
-                                        fa-hourglass-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-start">&#xf251</i>
-                                        fa-hourglass-start
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use houzz">&#xf27c</i>
-                                        fa-houzz
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use html5">&#xf13b</i>
-                                        fa-html5
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use i-cursor">&#xf246</i>
-                                        fa-i-cursor
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ils">&#xf20b</i>
-                                        fa-ils
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use image">&#xf03e</i>
-                                        fa-image
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use inbox">&#xf01c</i>
-                                        fa-inbox
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use indent">&#xf03c</i>
-                                        fa-indent
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use industry">&#xf275</i>
-                                        fa-industry
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use info">&#xf129</i>
-                                        fa-info
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use info-circle">&#xf05a</i>
-                                        fa-info-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use inr">&#xf156</i>
-                                        fa-inr
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use instagram">&#xf16d</i>
-                                        fa-instagram
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use institution">&#xf19c</i>
-                                        fa-institution
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use internet-explorer">&#xf26b</i>
-                                        fa-internet-explorer
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use intersex">&#xf224</i>
-                                        fa-intersex
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ioxhost">&#xf208</i>
-                                        fa-ioxhost
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use italic">&#xf033</i>
-                                        fa-italic
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use joomla">&#xf1aa</i>
-                                        fa-joomla
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use jpy">&#xf157</i>
-                                        fa-jpy
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use jsfiddle">&#xf1cc</i>
-                                        fa-jsfiddle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use key">&#xf084</i>
-                                        fa-key
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use keyboard-o">&#xf11c</i>
-                                        fa-keyboard-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use krw">&#xf159</i>
-                                        fa-krw
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use language">&#xf1ab</i>
-                                        fa-language
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use laptop">&#xf109</i>
-                                        fa-laptop
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use lastfm">&#xf202</i>
-                                        fa-lastfm
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use lastfm-square">&#xf203</i>
-                                        fa-lastfm-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use leaf">&#xf06c</i>
-                                        fa-leaf
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use leanpub">&#xf212</i>
-                                        fa-leanpub
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use legal">&#xf0e3</i>
-                                        fa-legal
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use lemon-o">&#xf094</i>
-                                        fa-lemon-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use level-down">&#xf149</i>
-                                        fa-level-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use level-up">&#xf148</i>
-                                        fa-level-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-bouy">&#xf1cd</i>
-                                        fa-life-bouy
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-buoy">&#xf1cd</i>
-                                        fa-life-buoy
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-ring">&#xf1cd</i>
-                                        fa-life-ring
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-saver">&#xf1cd</i>
-                                        fa-life-saver
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use lightbulb-o">&#xf0eb</i>
-                                        fa-lightbulb-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use line-chart">&#xf201</i>
-                                        fa-line-chart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use link">&#xf0c1</i>
-                                        fa-link
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use linkedin">&#xf0e1</i>
-                                        fa-linkedin
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use linkedin-square">&#xf08c</i>
-                                        fa-linkedin-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use linux">&#xf17c</i>
-                                        fa-linux
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use list">&#xf03a</i>
-                                        fa-list
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-alt">&#xf022</i>
-                                        fa-list-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-ol">&#xf0cb</i>
-                                        fa-list-ol
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-ul">&#xf0ca</i>
-                                        fa-list-ul
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use location-arrow">&#xf124</i>
-                                        fa-location-arrow
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use lock">&#xf023</i>
-                                        fa-lock
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-down">&#xf175</i>
-                                        fa-long-arrow-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-left">&#xf177</i>
-                                        fa-long-arrow-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-right">&#xf178</i>
-                                        fa-long-arrow-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-up">&#xf176</i>
-                                        fa-long-arrow-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use low-vision">&#xf2a8</i>
-                                        fa-low-vision
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use magic">&#xf0d0</i>
-                                        fa-magic
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use magnet">&#xf076</i>
-                                        fa-magnet
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-forward">&#xf064</i>
-                                        fa-mail-forward
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-reply">&#xf112</i>
-                                        fa-mail-reply
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-reply-all">&#xf122</i>
-                                        fa-mail-reply-all
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use male">&#xf183</i>
-                                        fa-male
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use map">&#xf279</i>
-                                        fa-map
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-marker">&#xf041</i>
-                                        fa-map-marker
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-o">&#xf278</i>
-                                        fa-map-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-pin">&#xf276</i>
-                                        fa-map-pin
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-signs">&#xf277</i>
-                                        fa-map-signs
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars">&#xf222</i>
-                                        fa-mars
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-double">&#xf227</i>
-                                        fa-mars-double
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke">&#xf229</i>
-                                        fa-mars-stroke
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke-h">&#xf22b</i>
-                                        fa-mars-stroke-h
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke-v">&#xf22a</i>
-                                        fa-mars-stroke-v
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use maxcdn">&#xf136</i>
-                                        fa-maxcdn
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use meanpath">&#xf20c</i>
-                                        fa-meanpath
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use medium">&#xf23a</i>
-                                        fa-medium
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use medkit">&#xf0fa</i>
-                                        fa-medkit
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use meh-o">&#xf11a</i>
-                                        fa-meh-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mercury">&#xf223</i>
-                                        fa-mercury
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use microphone">&#xf130</i>
-                                        fa-microphone
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use microphone-slash">&#xf131</i>
-                                        fa-microphone-slash
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus">&#xf068</i>
-                                        fa-minus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-circle">&#xf056</i>
-                                        fa-minus-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-square">&#xf146</i>
-                                        fa-minus-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-square-o">&#xf147</i>
-                                        fa-minus-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mixcloud">&#xf289</i>
-                                        fa-mixcloud
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mobile">&#xf10b</i>
-                                        fa-mobile
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mobile-phone">&#xf10b</i>
-                                        fa-mobile-phone
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use modx">&#xf285</i>
-                                        fa-modx
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use money">&#xf0d6</i>
-                                        fa-money
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use moon-o">&#xf186</i>
-                                        fa-moon-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mortar-board">&#xf19d</i>
-                                        fa-mortar-board
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use motorcycle">&#xf21c</i>
-                                        fa-motorcycle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use mouse-pointer">&#xf245</i>
-                                        fa-mouse-pointer
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use music">&#xf001</i>
-                                        fa-music
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use navicon">&#xf0c9</i>
-                                        fa-navicon
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use neuter">&#xf22c</i>
-                                        fa-neuter
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use newspaper-o">&#xf1ea</i>
-                                        fa-newspaper-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use object-group">&#xf247</i>
-                                        fa-object-group
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use object-ungroup">&#xf248</i>
-                                        fa-object-ungroup
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use odnoklassniki">&#xf263</i>
-                                        fa-odnoklassniki
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use odnoklassniki-square">&#xf264</i>
-                                        fa-odnoklassniki-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use opencart">&#xf23d</i>
-                                        fa-opencart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use openid">&#xf19b</i>
-                                        fa-openid
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use opera">&#xf26a</i>
-                                        fa-opera
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use optin-monster">&#xf23c</i>
-                                        fa-optin-monster
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use outdent">&#xf03b</i>
-                                        fa-outdent
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pagelines">&#xf18c</i>
-                                        fa-pagelines
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paint-brush">&#xf1fc</i>
-                                        fa-paint-brush
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paper-plane">&#xf1d8</i>
-                                        fa-paper-plane
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paper-plane-o">&#xf1d9</i>
-                                        fa-paper-plane-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paperclip">&#xf0c6</i>
-                                        fa-paperclip
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paragraph">&#xf1dd</i>
-                                        fa-paragraph
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paste">&#xf0ea</i>
-                                        fa-paste
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause">&#xf04c</i>
-                                        fa-pause
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause-circle">&#xf28b</i>
-                                        fa-pause-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause-circle-o">&#xf28c</i>
-                                        fa-pause-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paw">&#xf1b0</i>
-                                        fa-paw
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use paypal">&#xf1ed</i>
-                                        fa-paypal
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil">&#xf040</i>
-                                        fa-pencil
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil-square">&#xf14b</i>
-                                        fa-pencil-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil-square-o">&#xf044</i>
-                                        fa-pencil-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use percent">&#xf295</i>
-                                        fa-percent
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use phone">&#xf095</i>
-                                        fa-phone
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use phone-square">&#xf098</i>
-                                        fa-phone-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use photo">&#xf03e</i>
-                                        fa-photo
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use picture-o">&#xf03e</i>
-                                        fa-picture-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pie-chart">&#xf200</i>
-                                        fa-pie-chart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper">&#xf2ae</i>
-                                        fa-pied-piper
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper-alt">&#xf1a8</i>
-                                        fa-pied-piper-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper-pp">&#xf1a7</i>
-                                        fa-pied-piper-pp
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest">&#xf0d2</i>
-                                        fa-pinterest
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest-p">&#xf231</i>
-                                        fa-pinterest-p
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest-square">&#xf0d3</i>
-                                        fa-pinterest-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plane">&#xf072</i>
-                                        fa-plane
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use play">&#xf04b</i>
-                                        fa-play
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use play-circle">&#xf144</i>
-                                        fa-play-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use play-circle-o">&#xf01d</i>
-                                        fa-play-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plug">&#xf1e6</i>
-                                        fa-plug
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus">&#xf067</i>
-                                        fa-plus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-circle">&#xf055</i>
-                                        fa-plus-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-square">&#xf0fe</i>
-                                        fa-plus-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-square-o">&#xf196</i>
-                                        fa-plus-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use power-off">&#xf011</i>
-                                        fa-power-off
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use print">&#xf02f</i>
-                                        fa-print
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use product-hunt">&#xf288</i>
-                                        fa-product-hunt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use puzzle-piece">&#xf12e</i>
-                                        fa-puzzle-piece
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use qq">&#xf1d6</i>
-                                        fa-qq
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use qrcode">&#xf029</i>
-                                        fa-qrcode
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use question">&#xf128</i>
-                                        fa-question
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use question-circle">&#xf059</i>
-                                        fa-question-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use question-circle-o">&#xf29c</i>
-                                        fa-question-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use quote-left">&#xf10d</i>
-                                        fa-quote-left
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use quote-right">&#xf10e</i>
-                                        fa-quote-right
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ra">&#xf1d0</i>
-                                        fa-ra
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use random">&#xf074</i>
-                                        fa-random
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rebel">&#xf1d0</i>
-                                        fa-rebel
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use recycle">&#xf1b8</i>
-                                        fa-recycle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit">&#xf1a1</i>
-                                        fa-reddit
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit-alien">&#xf281</i>
-                                        fa-reddit-alien
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit-square">&#xf1a2</i>
-                                        fa-reddit-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use refresh">&#xf021</i>
-                                        fa-refresh
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use registered">&#xf25d</i>
-                                        fa-registered
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use remove">&#xf00d</i>
-                                        fa-remove
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use renren">&#xf18b</i>
-                                        fa-renren
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reorder">&#xf0c9</i>
-                                        fa-reorder
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use repeat">&#xf01e</i>
-                                        fa-repeat
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reply">&#xf112</i>
-                                        fa-reply
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use reply-all">&#xf122</i>
-                                        fa-reply-all
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use resistance">&#xf1d0</i>
-                                        fa-resistance
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use retweet">&#xf079</i>
-                                        fa-retweet
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rmb">&#xf157</i>
-                                        fa-rmb
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use road">&#xf018</i>
-                                        fa-road
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rocket">&#xf135</i>
-                                        fa-rocket
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rotate-left">&#xf0e2</i>
-                                        fa-rotate-left
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rotate-right">&#xf01e</i>
-                                        fa-rotate-right
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rouble">&#xf158</i>
-                                        fa-rouble
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rss">&#xf09e</i>
-                                        fa-rss
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rss-square">&#xf143</i>
-                                        fa-rss-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rub">&#xf158</i>
-                                        fa-rub
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ruble">&#xf158</i>
-                                        fa-ruble
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use rupee">&#xf156</i>
-                                        fa-rupee
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use safari">&#xf267</i>
-                                        fa-safari
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use save">&#xf0c7</i>
-                                        fa-save
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use scissors">&#xf0c4</i>
-                                        fa-scissors
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use scribd">&#xf28a</i>
-                                        fa-scribd
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use search">&#xf002</i>
-                                        fa-search
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use search-minus">&#xf010</i>
-                                        fa-search-minus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use search-plus">&#xf00e</i>
-                                        fa-search-plus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sellsy">&#xf213</i>
-                                        fa-sellsy
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use send">&#xf1d8</i>
-                                        fa-send
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use send-o">&#xf1d9</i>
-                                        fa-send-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use server">&#xf233</i>
-                                        fa-server
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use share">&#xf064</i>
-                                        fa-share
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-alt">&#xf1e0</i>
-                                        fa-share-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-alt-square">&#xf1e1</i>
-                                        fa-share-alt-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-square">&#xf14d</i>
-                                        fa-share-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-square-o">&#xf045</i>
-                                        fa-share-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shekel">&#xf20b</i>
-                                        fa-shekel
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sheqel">&#xf20b</i>
-                                        fa-sheqel
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shield">&#xf132</i>
-                                        fa-shield
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ship">&#xf21a</i>
-                                        fa-ship
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shirtsinbulk">&#xf214</i>
-                                        fa-shirtsinbulk
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-bag">&#xf290</i>
-                                        fa-shopping-bag
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-basket">&#xf291</i>
-                                        fa-shopping-basket
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-cart">&#xf07a</i>
-                                        fa-shopping-cart
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-in">&#xf090</i>
-                                        fa-sign-in
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-language">&#xf2a7</i>
-                                        fa-sign-language
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-out">&#xf08b</i>
-                                        fa-sign-out
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use signal">&#xf012</i>
-                                        fa-signal
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use signing">&#xf2a7</i>
-                                        fa-signing
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use simplybuilt">&#xf215</i>
-                                        fa-simplybuilt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sitemap">&#xf0e8</i>
-                                        fa-sitemap
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use skyatlas">&#xf216</i>
-                                        fa-skyatlas
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use skype">&#xf17e</i>
-                                        fa-skype
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use slack">&#xf198</i>
-                                        fa-slack
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sliders">&#xf1de</i>
-                                        fa-sliders
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use slideshare">&#xf1e7</i>
-                                        fa-slideshare
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use smile-o">&#xf118</i>
-                                        fa-smile-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat">&#xf2ab</i>
-                                        fa-snapchat
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat-ghost">&#xf2ac</i>
-                                        fa-snapchat-ghost
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat-square">&#xf2ad</i>
-                                        fa-snapchat-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use soccer-ball-o">&#xf1e3</i>
-                                        fa-soccer-ball-o
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort">&#xf0dc</i>
-                                        fa-sort
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-alpha-asc">&#xf15d</i>
-                                        fa-sort-alpha-asc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-alpha-desc">&#xf15e</i>
-                                        fa-sort-alpha-desc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-amount-asc">&#xf160</i>
-                                        fa-sort-amount-asc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-amount-desc">&#xf161</i>
-                                        fa-sort-amount-desc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-asc">&#xf0de</i>
-                                        fa-sort-asc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-desc">&#xf0dd</i>
-                                        fa-sort-desc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-down">&#xf0dd</i>
-                                        fa-sort-down
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-numeric-asc">&#xf162</i>
-                                        fa-sort-numeric-asc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-numeric-desc">&#xf163</i>
-                                        fa-sort-numeric-desc
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-up">&#xf0de</i>
-                                        fa-sort-up
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use soundcloud">&#xf1be</i>
-                                        fa-soundcloud
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use space-shuttle">&#xf197</i>
-                                        fa-space-shuttle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use spinner">&#xf110</i>
-                                        fa-spinner
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use spoon">&#xf1b1</i>
-                                        fa-spoon
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use spotify">&#xf1bc</i>
-                                        fa-spotify
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use square">&#xf0c8</i>
-                                        fa-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use square-o">&#xf096</i>
-                                        fa-square-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stack-exchange">&#xf18d</i>
-                                        fa-stack-exchange
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stack-overflow">&#xf16c</i>
-                                        fa-stack-overflow
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star">&#xf005</i>
-                                        fa-star
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half">&#xf089</i>
-                                        fa-star-half
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-empty">&#xf123</i>
-                                        fa-star-half-empty
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-full">&#xf123</i>
-                                        fa-star-half-full
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-o">&#xf123</i>
-                                        fa-star-half-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-o">&#xf006</i>
-                                        fa-star-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use steam">&#xf1b6</i>
-                                        fa-steam
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use steam-square">&#xf1b7</i>
-                                        fa-steam-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use step-backward">&#xf048</i>
-                                        fa-step-backward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use step-forward">&#xf051</i>
-                                        fa-step-forward
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stethoscope">&#xf0f1</i>
-                                        fa-stethoscope
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sticky-note">&#xf249</i>
-                                        fa-sticky-note
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sticky-note-o">&#xf24a</i>
-                                        fa-sticky-note-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop">&#xf04d</i>
-                                        fa-stop
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop-circle">&#xf28d</i>
-                                        fa-stop-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop-circle-o">&#xf28e</i>
-                                        fa-stop-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use street-view">&#xf21d</i>
-                                        fa-street-view
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use strikethrough">&#xf0cc</i>
-                                        fa-strikethrough
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stumbleupon">&#xf1a4</i>
-                                        fa-stumbleupon
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use stumbleupon-circle">&#xf1a3</i>
-                                        fa-stumbleupon-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use subscript">&#xf12c</i>
-                                        fa-subscript
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use subway">&#xf239</i>
-                                        fa-subway
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use suitcase">&#xf0f2</i>
-                                        fa-suitcase
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use sun-o">&#xf185</i>
-                                        fa-sun-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use superscript">&#xf12b</i>
-                                        fa-superscript
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use support">&#xf1cd</i>
-                                        fa-support
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use table">&#xf0ce</i>
-                                        fa-table
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tablet">&#xf10a</i>
-                                        fa-tablet
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tachometer">&#xf0e4</i>
-                                        fa-tachometer
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tag">&#xf02b</i>
-                                        fa-tag
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tags">&#xf02c</i>
-                                        fa-tags
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tasks">&#xf0ae</i>
-                                        fa-tasks
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use taxi">&#xf1ba</i>
-                                        fa-taxi
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use television">&#xf26c</i>
-                                        fa-television
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tencent-weibo">&#xf1d5</i>
-                                        fa-tencent-weibo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use terminal">&#xf120</i>
-                                        fa-terminal
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use text-height">&#xf034</i>
-                                        fa-text-height
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use text-width">&#xf035</i>
-                                        fa-text-width
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use th">&#xf00a</i>
-                                        fa-th
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use th-large">&#xf009</i>
-                                        fa-th-large
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use th-list">&#xf00b</i>
-                                        fa-th-list
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use themeisle">&#xf2b2</i>
-                                        fa-themeisle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumb-tack">&#xf08d</i>
-                                        fa-thumb-tack
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-down">&#xf165</i>
-                                        fa-thumbs-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-o-down">&#xf088</i>
-                                        fa-thumbs-o-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-o-up">&#xf087</i>
-                                        fa-thumbs-o-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-up">&#xf164</i>
-                                        fa-thumbs-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use ticket">&#xf145</i>
-                                        fa-ticket
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use times">&#xf00d</i>
-                                        fa-times
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use times-circle">&#xf057</i>
-                                        fa-times-circle
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use times-circle-o">&#xf05c</i>
-                                        fa-times-circle-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tint">&#xf043</i>
-                                        fa-tint
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-down">&#xf150</i>
-                                        fa-toggle-down
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-left">&#xf191</i>
-                                        fa-toggle-left
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-off">&#xf204</i>
-                                        fa-toggle-off
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-on">&#xf205</i>
-                                        fa-toggle-on
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-right">&#xf152</i>
-                                        fa-toggle-right
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-up">&#xf151</i>
-                                        fa-toggle-up
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use trademark">&#xf25c</i>
-                                        fa-trademark
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use train">&#xf238</i>
-                                        fa-train
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use transgender">&#xf224</i>
-                                        fa-transgender
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use transgender-alt">&#xf225</i>
-                                        fa-transgender-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use trash">&#xf1f8</i>
-                                        fa-trash
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use trash-o">&#xf014</i>
-                                        fa-trash-o
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tree">&#xf1bb</i>
-                                        fa-tree
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use trello">&#xf181</i>
-                                        fa-trello
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tripadvisor">&#xf262</i>
-                                        fa-tripadvisor
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use trophy">&#xf091</i>
-                                        fa-trophy
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use truck">&#xf0d1</i>
-                                        fa-truck
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use try">&#xf195</i>
-                                        fa-try
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tty">&#xf1e4</i>
-                                        fa-tty
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tumblr">&#xf173</i>
-                                        fa-tumblr
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tumblr-square">&#xf174</i>
-                                        fa-tumblr-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use turkish-lira">&#xf195</i>
-                                        fa-turkish-lira
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use tv">&#xf26c</i>
-                                        fa-tv
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitch">&#xf1e8</i>
-                                        fa-twitch
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitter">&#xf099</i>
-                                        fa-twitter
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitter-square">&#xf081</i>
-                                        fa-twitter-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use umbrella">&#xf0e9</i>
-                                        fa-umbrella
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use underline">&#xf0cd</i>
-                                        fa-underline
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use undo">&#xf0e2</i>
-                                        fa-undo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use universal-access">&#xf29a</i>
-                                        fa-universal-access
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use university">&#xf19c</i>
-                                        fa-university
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlink">&#xf127</i>
-                                        fa-unlink
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlock">&#xf09c</i>
-                                        fa-unlock
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlock-alt">&#xf13e</i>
-                                        fa-unlock-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use unsorted">&#xf0dc</i>
-                                        fa-unsorted
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use upload">&#xf093</i>
-                                        fa-upload
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use usb">&#xf287</i>
-                                        fa-usb
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use usd">&#xf155</i>
-                                        fa-usd
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use user">&#xf007</i>
-                                        fa-user
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-md">&#xf0f0</i>
-                                        fa-user-md
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-plus">&#xf234</i>
-                                        fa-user-plus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-secret">&#xf21b</i>
-                                        fa-user-secret
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-times">&#xf235</i>
-                                        fa-user-times
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use users">&#xf0c0</i>
-                                        fa-users
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus">&#xf221</i>
-                                        fa-venus
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus-double">&#xf226</i>
-                                        fa-venus-double
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus-mars">&#xf228</i>
-                                        fa-venus-mars
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use viacoin">&#xf237</i>
-                                        fa-viacoin
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use viadeo">&#xf2a9</i>
-                                        fa-viadeo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use viadeo-square">&#xf2aa</i>
-                                        fa-viadeo-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use video-camera">&#xf03d</i>
-                                        fa-video-camera
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use vimeo">&#xf27d</i>
-                                        fa-vimeo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use vimeo-square">&#xf194</i>
-                                        fa-vimeo-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use vine">&#xf1ca</i>
-                                        fa-vine
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use vk">&#xf189</i>
-                                        fa-vk
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-control-phone">&#xf2a0</i>
-                                        fa-volume-control-phone
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-down">&#xf027</i>
-                                        fa-volume-down
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-off">&#xf026</i>
-                                        fa-volume-off
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-up">&#xf028</i>
-                                        fa-volume-up
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use warning">&#xf071</i>
-                                        fa-warning
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wechat">&#xf1d7</i>
-                                        fa-wechat
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use weibo">&#xf18a</i>
-                                        fa-weibo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use weixin">&#xf1d7</i>
-                                        fa-weixin
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use whatsapp">&#xf232</i>
-                                        fa-whatsapp
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wheelchair">&#xf193</i>
-                                        fa-wheelchair
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wheelchair-alt">&#xf29b</i>
-                                        fa-wheelchair-alt
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wifi">&#xf1eb</i>
-                                        fa-wifi
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wikipedia-w">&#xf266</i>
-                                        fa-wikipedia-w
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use windows">&#xf17a</i>
-                                        fa-windows
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use won">&#xf159</i>
-                                        fa-won
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wordpress">&#xf19a</i>
-                                        fa-wordpress
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wpbeginner">&#xf297</i>
-                                        fa-wpbeginner
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wpforms">&#xf298</i>
-                                        fa-wpforms
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use wrench">&#xf0ad</i>
-                                        fa-wrench
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use xing">&#xf168</i>
-                                        fa-xing
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use xing-square">&#xf169</i>
-                                        fa-xing-square
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use y-combinator">&#xf23b</i>
-                                        fa-y-combinator
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use y-combinator-square">&#xf1d4</i>
-                                        fa-y-combinator-square
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yahoo">&#xf19e</i>
-                                        fa-yahoo
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yc">&#xf23b</i>
-                                        fa-yc
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yc-square">&#xf1d4</i>
-                                        fa-yc-square
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yelp">&#xf1e9</i>
-                                        fa-yelp
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yen">&#xf157</i>
-                                        fa-yen
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-                                        
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use yoast">&#xf2b1</i>
-                                        fa-yoast
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube">&#xf167</i>
-                                        fa-youtube
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube-play">&#xf16a</i>
-                                        fa-youtube-play
-
-                                    </div>
-
-                                    <div class="col-md-4 col-sm-6 col-lg-3">
-
-                                        <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube-square">&#xf166</i>
-                                        fa-youtube-square
-
-                                    </div>
-
-                                </div>
-                                <!-- /.row (nested) -->
-                            </div>
-                            <!-- /.panel-body -->
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Icons</h1>
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    All available icons
+                                </div>
+                                <div class="panel-body">
+
+                                    <div class="row">
+
+
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use 500px">&#xf26e</i>
+                                            fa-500px
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use adjust">&#xf042</i>
+                                            fa-adjust
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use adn">&#xf170</i>
+                                            fa-adn
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-center">&#xf037</i>
+                                            fa-align-center
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-justify">&#xf039</i>
+                                            fa-align-justify
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-left">&#xf036</i>
+                                            fa-align-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use align-right">&#xf038</i>
+                                            fa-align-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use amazon">&#xf270</i>
+                                            fa-amazon
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ambulance">&#xf0f9</i>
+                                            fa-ambulance
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use american-sign-language-interpreting">&#xf2a3</i>
+                                            fa-american-sign-language-interpreting
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use anchor">&#xf13d</i>
+                                            fa-anchor
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use android">&#xf17b</i>
+                                            fa-android
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angellist">&#xf209</i>
+                                            fa-angellist
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-down">&#xf103</i>
+                                            fa-angle-double-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-left">&#xf100</i>
+                                            fa-angle-double-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-right">&#xf101</i>
+                                            fa-angle-double-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-double-up">&#xf102</i>
+                                            fa-angle-double-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-down">&#xf107</i>
+                                            fa-angle-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-left">&#xf104</i>
+                                            fa-angle-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-right">&#xf105</i>
+                                            fa-angle-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use angle-up">&#xf106</i>
+                                            fa-angle-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use apple">&#xf179</i>
+                                            fa-apple
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use archive">&#xf187</i>
+                                            fa-archive
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use area-chart">&#xf1fe</i>
+                                            fa-area-chart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-down">&#xf0ab</i>
+                                            fa-arrow-circle-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-left">&#xf0a8</i>
+                                            fa-arrow-circle-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-down">&#xf01a</i>
+                                            fa-arrow-circle-o-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-left">&#xf190</i>
+                                            fa-arrow-circle-o-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-right">&#xf18e</i>
+                                            fa-arrow-circle-o-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-o-up">&#xf01b</i>
+                                            fa-arrow-circle-o-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-right">&#xf0a9</i>
+                                            fa-arrow-circle-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-circle-up">&#xf0aa</i>
+                                            fa-arrow-circle-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-down">&#xf063</i>
+                                            fa-arrow-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-left">&#xf060</i>
+                                            fa-arrow-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-right">&#xf061</i>
+                                            fa-arrow-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrow-up">&#xf062</i>
+                                            fa-arrow-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows">&#xf047</i>
+                                            fa-arrows
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-alt">&#xf0b2</i>
+                                            fa-arrows-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-h">&#xf07e</i>
+                                            fa-arrows-h
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use arrows-v">&#xf07d</i>
+                                            fa-arrows-v
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use asl-interpreting">&#xf2a3</i>
+                                            fa-asl-interpreting
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use assistive-listening-systems">&#xf2a2</i>
+                                            fa-assistive-listening-systems
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use asterisk">&#xf069</i>
+                                            fa-asterisk
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use at">&#xf1fa</i>
+                                            fa-at
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use audio-description">&#xf29e</i>
+                                            fa-audio-description
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use automobile">&#xf1b9</i>
+                                            fa-automobile
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use backward">&#xf04a</i>
+                                            fa-backward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use balance-scale">&#xf24e</i>
+                                            fa-balance-scale
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ban">&#xf05e</i>
+                                            fa-ban
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bank">&#xf19c</i>
+                                            fa-bank
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bar-chart">&#xf080</i>
+                                            fa-bar-chart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bar-chart-o">&#xf080</i>
+                                            fa-bar-chart-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use barcode">&#xf02a</i>
+                                            fa-barcode
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bars">&#xf0c9</i>
+                                            fa-bars
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-0">&#xf244</i>
+                                            fa-battery-0
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-1">&#xf243</i>
+                                            fa-battery-1
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-2">&#xf242</i>
+                                            fa-battery-2
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-3">&#xf241</i>
+                                            fa-battery-3
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-4">&#xf240</i>
+                                            fa-battery-4
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-empty">&#xf244</i>
+                                            fa-battery-empty
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-full">&#xf240</i>
+                                            fa-battery-full
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-half">&#xf242</i>
+                                            fa-battery-half
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-quarter">&#xf243</i>
+                                            fa-battery-quarter
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use battery-three-quarters">&#xf241</i>
+                                            fa-battery-three-quarters
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bed">&#xf236</i>
+                                            fa-bed
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use beer">&#xf0fc</i>
+                                            fa-beer
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use behance">&#xf1b4</i>
+                                            fa-behance
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use behance-square">&#xf1b5</i>
+                                            fa-behance-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell">&#xf0f3</i>
+                                            fa-bell
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-o">&#xf0a2</i>
+                                            fa-bell-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-slash">&#xf1f6</i>
+                                            fa-bell-slash
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bell-slash-o">&#xf1f7</i>
+                                            fa-bell-slash-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bicycle">&#xf206</i>
+                                            fa-bicycle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use binoculars">&#xf1e5</i>
+                                            fa-binoculars
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use birthday-cake">&#xf1fd</i>
+                                            fa-birthday-cake
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitbucket">&#xf171</i>
+                                            fa-bitbucket
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitbucket-square">&#xf172</i>
+                                            fa-bitbucket-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bitcoin">&#xf15a</i>
+                                            fa-bitcoin
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use black-tie">&#xf27e</i>
+                                            fa-black-tie
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use blind">&#xf29d</i>
+                                            fa-blind
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bluetooth">&#xf293</i>
+                                            fa-bluetooth
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bluetooth-b">&#xf294</i>
+                                            fa-bluetooth-b
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bold">&#xf032</i>
+                                            fa-bold
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bolt">&#xf0e7</i>
+                                            fa-bolt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bomb">&#xf1e2</i>
+                                            fa-bomb
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use book">&#xf02d</i>
+                                            fa-book
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bookmark">&#xf02e</i>
+                                            fa-bookmark
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bookmark-o">&#xf097</i>
+                                            fa-bookmark-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use braille">&#xf2a1</i>
+                                            fa-braille
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use briefcase">&#xf0b1</i>
+                                            fa-briefcase
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use btc">&#xf15a</i>
+                                            fa-btc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bug">&#xf188</i>
+                                            fa-bug
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use building">&#xf1ad</i>
+                                            fa-building
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use building-o">&#xf0f7</i>
+                                            fa-building-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bullhorn">&#xf0a1</i>
+                                            fa-bullhorn
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bullseye">&#xf140</i>
+                                            fa-bullseye
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use bus">&#xf207</i>
+                                            fa-bus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use buysellads">&#xf20d</i>
+                                            fa-buysellads
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cab">&#xf1ba</i>
+                                            fa-cab
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calculator">&#xf1ec</i>
+                                            fa-calculator
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar">&#xf073</i>
+                                            fa-calendar
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-check-o">&#xf274</i>
+                                            fa-calendar-check-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-minus-o">&#xf272</i>
+                                            fa-calendar-minus-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-o">&#xf133</i>
+                                            fa-calendar-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-plus-o">&#xf271</i>
+                                            fa-calendar-plus-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use calendar-times-o">&#xf273</i>
+                                            fa-calendar-times-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use camera">&#xf030</i>
+                                            fa-camera
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use camera-retro">&#xf083</i>
+                                            fa-camera-retro
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use car">&#xf1b9</i>
+                                            fa-car
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-down">&#xf0d7</i>
+                                            fa-caret-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-left">&#xf0d9</i>
+                                            fa-caret-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-right">&#xf0da</i>
+                                            fa-caret-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-down">&#xf150</i>
+                                            fa-caret-square-o-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-left">&#xf191</i>
+                                            fa-caret-square-o-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-right">&#xf152</i>
+                                            fa-caret-square-o-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-square-o-up">&#xf151</i>
+                                            fa-caret-square-o-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use caret-up">&#xf0d8</i>
+                                            fa-caret-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cart-arrow-down">&#xf218</i>
+                                            fa-cart-arrow-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cart-plus">&#xf217</i>
+                                            fa-cart-plus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc">&#xf20a</i>
+                                            fa-cc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-amex">&#xf1f3</i>
+                                            fa-cc-amex
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-diners-club">&#xf24c</i>
+                                            fa-cc-diners-club
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-discover">&#xf1f2</i>
+                                            fa-cc-discover
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-jcb">&#xf24b</i>
+                                            fa-cc-jcb
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-mastercard">&#xf1f1</i>
+                                            fa-cc-mastercard
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-paypal">&#xf1f4</i>
+                                            fa-cc-paypal
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-stripe">&#xf1f5</i>
+                                            fa-cc-stripe
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cc-visa">&#xf1f0</i>
+                                            fa-cc-visa
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use certificate">&#xf0a3</i>
+                                            fa-certificate
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chain">&#xf0c1</i>
+                                            fa-chain
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chain-broken">&#xf127</i>
+                                            fa-chain-broken
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use check">&#xf00c</i>
+                                            fa-check
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-circle">&#xf058</i>
+                                            fa-check-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-circle-o">&#xf05d</i>
+                                            fa-check-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-square">&#xf14a</i>
+                                            fa-check-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use check-square-o">&#xf046</i>
+                                            fa-check-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-down">&#xf13a</i>
+                                            fa-chevron-circle-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-left">&#xf137</i>
+                                            fa-chevron-circle-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-right">&#xf138</i>
+                                            fa-chevron-circle-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-circle-up">&#xf139</i>
+                                            fa-chevron-circle-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-down">&#xf078</i>
+                                            fa-chevron-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-left">&#xf053</i>
+                                            fa-chevron-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-right">&#xf054</i>
+                                            fa-chevron-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chevron-up">&#xf077</i>
+                                            fa-chevron-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use child">&#xf1ae</i>
+                                            fa-child
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use chrome">&#xf268</i>
+                                            fa-chrome
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle">&#xf111</i>
+                                            fa-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-o">&#xf10c</i>
+                                            fa-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-o-notch">&#xf1ce</i>
+                                            fa-circle-o-notch
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use circle-thin">&#xf1db</i>
+                                            fa-circle-thin
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use clipboard">&#xf0ea</i>
+                                            fa-clipboard
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use clock-o">&#xf017</i>
+                                            fa-clock-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use clone">&#xf24d</i>
+                                            fa-clone
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use close">&#xf00d</i>
+                                            fa-close
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud">&#xf0c2</i>
+                                            fa-cloud
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud-download">&#xf0ed</i>
+                                            fa-cloud-download
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cloud-upload">&#xf0ee</i>
+                                            fa-cloud-upload
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cny">&#xf157</i>
+                                            fa-cny
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use code">&#xf121</i>
+                                            fa-code
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use code-fork">&#xf126</i>
+                                            fa-code-fork
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use codepen">&#xf1cb</i>
+                                            fa-codepen
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use codiepie">&#xf284</i>
+                                            fa-codiepie
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use coffee">&#xf0f4</i>
+                                            fa-coffee
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cog">&#xf013</i>
+                                            fa-cog
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cogs">&#xf085</i>
+                                            fa-cogs
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use columns">&#xf0db</i>
+                                            fa-columns
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use comment">&#xf075</i>
+                                            fa-comment
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use comment-o">&#xf0e5</i>
+                                            fa-comment-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use commenting">&#xf27a</i>
+                                            fa-commenting
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use commenting-o">&#xf27b</i>
+                                            fa-commenting-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use comments">&#xf086</i>
+                                            fa-comments
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use comments-o">&#xf0e6</i>
+                                            fa-comments-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use compass">&#xf14e</i>
+                                            fa-compass
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use compress">&#xf066</i>
+                                            fa-compress
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use connectdevelop">&#xf20e</i>
+                                            fa-connectdevelop
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use contao">&#xf26d</i>
+                                            fa-contao
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use copy">&#xf0c5</i>
+                                            fa-copy
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use copyright">&#xf1f9</i>
+                                            fa-copyright
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use creative-commons">&#xf25e</i>
+                                            fa-creative-commons
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use credit-card">&#xf09d</i>
+                                            fa-credit-card
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use credit-card-alt">&#xf283</i>
+                                            fa-credit-card-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use crop">&#xf125</i>
+                                            fa-crop
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use crosshairs">&#xf05b</i>
+                                            fa-crosshairs
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use css3">&#xf13c</i>
+                                            fa-css3
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cube">&#xf1b2</i>
+                                            fa-cube
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cubes">&#xf1b3</i>
+                                            fa-cubes
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cut">&#xf0c4</i>
+                                            fa-cut
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use cutlery">&#xf0f5</i>
+                                            fa-cutlery
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dashboard">&#xf0e4</i>
+                                            fa-dashboard
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dashcube">&#xf210</i>
+                                            fa-dashcube
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use database">&#xf1c0</i>
+                                            fa-database
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use deaf">&#xf2a4</i>
+                                            fa-deaf
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use deafness">&#xf2a4</i>
+                                            fa-deafness
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dedent">&#xf03b</i>
+                                            fa-dedent
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use delicious">&#xf1a5</i>
+                                            fa-delicious
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use desktop">&#xf108</i>
+                                            fa-desktop
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use deviantart">&#xf1bd</i>
+                                            fa-deviantart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use diamond">&#xf219</i>
+                                            fa-diamond
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use digg">&#xf1a6</i>
+                                            fa-digg
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dollar">&#xf155</i>
+                                            fa-dollar
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dot-circle-o">&#xf192</i>
+                                            fa-dot-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use download">&#xf019</i>
+                                            fa-download
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dribbble">&#xf17d</i>
+                                            fa-dribbble
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use dropbox">&#xf16b</i>
+                                            fa-dropbox
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use drupal">&#xf1a9</i>
+                                            fa-drupal
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use edge">&#xf282</i>
+                                            fa-edge
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use edit">&#xf044</i>
+                                            fa-edit
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eject">&#xf052</i>
+                                            fa-eject
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ellipsis-h">&#xf141</i>
+                                            fa-ellipsis-h
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ellipsis-v">&#xf142</i>
+                                            fa-ellipsis-v
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use empire">&#xf1d1</i>
+                                            fa-empire
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope">&#xf0e0</i>
+                                            fa-envelope
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope-o">&#xf003</i>
+                                            fa-envelope-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use envelope-square">&#xf199</i>
+                                            fa-envelope-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use envira">&#xf299</i>
+                                            fa-envira
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eraser">&#xf12d</i>
+                                            fa-eraser
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eur">&#xf153</i>
+                                            fa-eur
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use euro">&#xf153</i>
+                                            fa-euro
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use exchange">&#xf0ec</i>
+                                            fa-exchange
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation">&#xf12a</i>
+                                            fa-exclamation
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation-circle">&#xf06a</i>
+                                            fa-exclamation-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use exclamation-triangle">&#xf071</i>
+                                            fa-exclamation-triangle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use expand">&#xf065</i>
+                                            fa-expand
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use expeditedssl">&#xf23e</i>
+                                            fa-expeditedssl
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use external-link">&#xf08e</i>
+                                            fa-external-link
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use external-link-square">&#xf14c</i>
+                                            fa-external-link-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eye">&#xf06e</i>
+                                            fa-eye
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eye-slash">&#xf070</i>
+                                            fa-eye-slash
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use eyedropper">&#xf1fb</i>
+                                            fa-eyedropper
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fa">&#xf2b4</i>
+                                            fa-fa
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook">&#xf09a</i>
+                                            fa-facebook
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-f">&#xf09a</i>
+                                            fa-facebook-f
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-official">&#xf230</i>
+                                            fa-facebook-official
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use facebook-square">&#xf082</i>
+                                            fa-facebook-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fast-backward">&#xf049</i>
+                                            fa-fast-backward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fast-forward">&#xf050</i>
+                                            fa-fast-forward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fax">&#xf1ac</i>
+                                            fa-fax
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use feed">&#xf09e</i>
+                                            fa-feed
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use female">&#xf182</i>
+                                            fa-female
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fighter-jet">&#xf0fb</i>
+                                            fa-fighter-jet
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file">&#xf15b</i>
+                                            fa-file
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-archive-o">&#xf1c6</i>
+                                            fa-file-archive-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-audio-o">&#xf1c7</i>
+                                            fa-file-audio-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-code-o">&#xf1c9</i>
+                                            fa-file-code-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-excel-o">&#xf1c3</i>
+                                            fa-file-excel-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-image-o">&#xf1c5</i>
+                                            fa-file-image-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-movie-o">&#xf1c8</i>
+                                            fa-file-movie-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-o">&#xf016</i>
+                                            fa-file-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-pdf-o">&#xf1c1</i>
+                                            fa-file-pdf-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-photo-o">&#xf1c5</i>
+                                            fa-file-photo-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-picture-o">&#xf1c5</i>
+                                            fa-file-picture-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-powerpoint-o">&#xf1c4</i>
+                                            fa-file-powerpoint-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-sound-o">&#xf1c7</i>
+                                            fa-file-sound-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-text">&#xf15c</i>
+                                            fa-file-text
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-text-o">&#xf0f6</i>
+                                            fa-file-text-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-video-o">&#xf1c8</i>
+                                            fa-file-video-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-word-o">&#xf1c2</i>
+                                            fa-file-word-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use file-zip-o">&#xf1c6</i>
+                                            fa-file-zip-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use files-o">&#xf0c5</i>
+                                            fa-files-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use film">&#xf008</i>
+                                            fa-film
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use filter">&#xf0b0</i>
+                                            fa-filter
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fire">&#xf06d</i>
+                                            fa-fire
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fire-extinguisher">&#xf134</i>
+                                            fa-fire-extinguisher
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use firefox">&#xf269</i>
+                                            fa-firefox
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use first-order">&#xf2b0</i>
+                                            fa-first-order
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag">&#xf024</i>
+                                            fa-flag
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag-checkered">&#xf11e</i>
+                                            fa-flag-checkered
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flag-o">&#xf11d</i>
+                                            fa-flag-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flash">&#xf0e7</i>
+                                            fa-flash
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flask">&#xf0c3</i>
+                                            fa-flask
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use flickr">&#xf16e</i>
+                                            fa-flickr
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use floppy-o">&#xf0c7</i>
+                                            fa-floppy-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder">&#xf07b</i>
+                                            fa-folder
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-o">&#xf114</i>
+                                            fa-folder-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-open">&#xf07c</i>
+                                            fa-folder-open
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use folder-open-o">&#xf115</i>
+                                            fa-folder-open-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use font">&#xf031</i>
+                                            fa-font
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use font-awesome">&#xf2b4</i>
+                                            fa-font-awesome
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fonticons">&#xf280</i>
+                                            fa-fonticons
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use fort-awesome">&#xf286</i>
+                                            fa-fort-awesome
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use forumbee">&#xf211</i>
+                                            fa-forumbee
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use forward">&#xf04e</i>
+                                            fa-forward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use foursquare">&#xf180</i>
+                                            fa-foursquare
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use frown-o">&#xf119</i>
+                                            fa-frown-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use futbol-o">&#xf1e3</i>
+                                            fa-futbol-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gamepad">&#xf11b</i>
+                                            fa-gamepad
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gavel">&#xf0e3</i>
+                                            fa-gavel
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gbp">&#xf154</i>
+                                            fa-gbp
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ge">&#xf1d1</i>
+                                            fa-ge
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gear">&#xf013</i>
+                                            fa-gear
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gears">&#xf085</i>
+                                            fa-gears
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use genderless">&#xf22d</i>
+                                            fa-genderless
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use get-pocket">&#xf265</i>
+                                            fa-get-pocket
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gg">&#xf260</i>
+                                            fa-gg
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gg-circle">&#xf261</i>
+                                            fa-gg-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gift">&#xf06b</i>
+                                            fa-gift
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use git">&#xf1d3</i>
+                                            fa-git
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use git-square">&#xf1d2</i>
+                                            fa-git-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use github">&#xf09b</i>
+                                            fa-github
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use github-alt">&#xf113</i>
+                                            fa-github-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use github-square">&#xf092</i>
+                                            fa-github-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gitlab">&#xf296</i>
+                                            fa-gitlab
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gittip">&#xf184</i>
+                                            fa-gittip
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use glass">&#xf000</i>
+                                            fa-glass
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use glide">&#xf2a5</i>
+                                            fa-glide
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use glide-g">&#xf2a6</i>
+                                            fa-glide-g
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use globe">&#xf0ac</i>
+                                            fa-globe
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google">&#xf1a0</i>
+                                            fa-google
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus">&#xf0d5</i>
+                                            fa-google-plus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-circle">&#xf2b3</i>
+                                            fa-google-plus-circle
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-official">&#xf2b3</i>
+                                            fa-google-plus-official
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-plus-square">&#xf0d4</i>
+                                            fa-google-plus-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use google-wallet">&#xf1ee</i>
+                                            fa-google-wallet
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use graduation-cap">&#xf19d</i>
+                                            fa-graduation-cap
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use gratipay">&#xf184</i>
+                                            fa-gratipay
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use group">&#xf0c0</i>
+                                            fa-group
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use h-square">&#xf0fd</i>
+                                            fa-h-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hacker-news">&#xf1d4</i>
+                                            fa-hacker-news
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-grab-o">&#xf255</i>
+                                            fa-hand-grab-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-lizard-o">&#xf258</i>
+                                            fa-hand-lizard-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-down">&#xf0a7</i>
+                                            fa-hand-o-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-left">&#xf0a5</i>
+                                            fa-hand-o-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-right">&#xf0a4</i>
+                                            fa-hand-o-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-o-up">&#xf0a6</i>
+                                            fa-hand-o-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-paper-o">&#xf256</i>
+                                            fa-hand-paper-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-peace-o">&#xf25b</i>
+                                            fa-hand-peace-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-pointer-o">&#xf25a</i>
+                                            fa-hand-pointer-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-rock-o">&#xf255</i>
+                                            fa-hand-rock-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-scissors-o">&#xf257</i>
+                                            fa-hand-scissors-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-spock-o">&#xf259</i>
+                                            fa-hand-spock-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hand-stop-o">&#xf256</i>
+                                            fa-hand-stop-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hard-of-hearing">&#xf2a4</i>
+                                            fa-hard-of-hearing
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hashtag">&#xf292</i>
+                                            fa-hashtag
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hdd-o">&#xf0a0</i>
+                                            fa-hdd-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use header">&#xf1dc</i>
+                                            fa-header
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use headphones">&#xf025</i>
+                                            fa-headphones
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use heart">&#xf004</i>
+                                            fa-heart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use heart-o">&#xf08a</i>
+                                            fa-heart-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use heartbeat">&#xf21e</i>
+                                            fa-heartbeat
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use history">&#xf1da</i>
+                                            fa-history
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use home">&#xf015</i>
+                                            fa-home
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hospital-o">&#xf0f8</i>
+                                            fa-hospital-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hotel">&#xf236</i>
+                                            fa-hotel
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass">&#xf254</i>
+                                            fa-hourglass
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-1">&#xf251</i>
+                                            fa-hourglass-1
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-2">&#xf252</i>
+                                            fa-hourglass-2
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-3">&#xf253</i>
+                                            fa-hourglass-3
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-end">&#xf253</i>
+                                            fa-hourglass-end
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-half">&#xf252</i>
+                                            fa-hourglass-half
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-o">&#xf250</i>
+                                            fa-hourglass-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use hourglass-start">&#xf251</i>
+                                            fa-hourglass-start
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use houzz">&#xf27c</i>
+                                            fa-houzz
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use html5">&#xf13b</i>
+                                            fa-html5
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use i-cursor">&#xf246</i>
+                                            fa-i-cursor
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ils">&#xf20b</i>
+                                            fa-ils
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use image">&#xf03e</i>
+                                            fa-image
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use inbox">&#xf01c</i>
+                                            fa-inbox
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use indent">&#xf03c</i>
+                                            fa-indent
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use industry">&#xf275</i>
+                                            fa-industry
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use info">&#xf129</i>
+                                            fa-info
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use info-circle">&#xf05a</i>
+                                            fa-info-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use inr">&#xf156</i>
+                                            fa-inr
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use instagram">&#xf16d</i>
+                                            fa-instagram
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use institution">&#xf19c</i>
+                                            fa-institution
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use internet-explorer">&#xf26b</i>
+                                            fa-internet-explorer
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use intersex">&#xf224</i>
+                                            fa-intersex
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ioxhost">&#xf208</i>
+                                            fa-ioxhost
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use italic">&#xf033</i>
+                                            fa-italic
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use joomla">&#xf1aa</i>
+                                            fa-joomla
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use jpy">&#xf157</i>
+                                            fa-jpy
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use jsfiddle">&#xf1cc</i>
+                                            fa-jsfiddle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use key">&#xf084</i>
+                                            fa-key
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use keyboard-o">&#xf11c</i>
+                                            fa-keyboard-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use krw">&#xf159</i>
+                                            fa-krw
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use language">&#xf1ab</i>
+                                            fa-language
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use laptop">&#xf109</i>
+                                            fa-laptop
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use lastfm">&#xf202</i>
+                                            fa-lastfm
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use lastfm-square">&#xf203</i>
+                                            fa-lastfm-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use leaf">&#xf06c</i>
+                                            fa-leaf
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use leanpub">&#xf212</i>
+                                            fa-leanpub
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use legal">&#xf0e3</i>
+                                            fa-legal
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use lemon-o">&#xf094</i>
+                                            fa-lemon-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use level-down">&#xf149</i>
+                                            fa-level-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use level-up">&#xf148</i>
+                                            fa-level-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-bouy">&#xf1cd</i>
+                                            fa-life-bouy
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-buoy">&#xf1cd</i>
+                                            fa-life-buoy
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-ring">&#xf1cd</i>
+                                            fa-life-ring
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use life-saver">&#xf1cd</i>
+                                            fa-life-saver
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use lightbulb-o">&#xf0eb</i>
+                                            fa-lightbulb-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use line-chart">&#xf201</i>
+                                            fa-line-chart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use link">&#xf0c1</i>
+                                            fa-link
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use linkedin">&#xf0e1</i>
+                                            fa-linkedin
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use linkedin-square">&#xf08c</i>
+                                            fa-linkedin-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use linux">&#xf17c</i>
+                                            fa-linux
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use list">&#xf03a</i>
+                                            fa-list
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-alt">&#xf022</i>
+                                            fa-list-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-ol">&#xf0cb</i>
+                                            fa-list-ol
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use list-ul">&#xf0ca</i>
+                                            fa-list-ul
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use location-arrow">&#xf124</i>
+                                            fa-location-arrow
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use lock">&#xf023</i>
+                                            fa-lock
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-down">&#xf175</i>
+                                            fa-long-arrow-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-left">&#xf177</i>
+                                            fa-long-arrow-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-right">&#xf178</i>
+                                            fa-long-arrow-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use long-arrow-up">&#xf176</i>
+                                            fa-long-arrow-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use low-vision">&#xf2a8</i>
+                                            fa-low-vision
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use magic">&#xf0d0</i>
+                                            fa-magic
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use magnet">&#xf076</i>
+                                            fa-magnet
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-forward">&#xf064</i>
+                                            fa-mail-forward
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-reply">&#xf112</i>
+                                            fa-mail-reply
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mail-reply-all">&#xf122</i>
+                                            fa-mail-reply-all
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use male">&#xf183</i>
+                                            fa-male
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use map">&#xf279</i>
+                                            fa-map
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-marker">&#xf041</i>
+                                            fa-map-marker
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-o">&#xf278</i>
+                                            fa-map-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-pin">&#xf276</i>
+                                            fa-map-pin
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use map-signs">&#xf277</i>
+                                            fa-map-signs
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars">&#xf222</i>
+                                            fa-mars
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-double">&#xf227</i>
+                                            fa-mars-double
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke">&#xf229</i>
+                                            fa-mars-stroke
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke-h">&#xf22b</i>
+                                            fa-mars-stroke-h
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mars-stroke-v">&#xf22a</i>
+                                            fa-mars-stroke-v
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use maxcdn">&#xf136</i>
+                                            fa-maxcdn
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use meanpath">&#xf20c</i>
+                                            fa-meanpath
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use medium">&#xf23a</i>
+                                            fa-medium
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use medkit">&#xf0fa</i>
+                                            fa-medkit
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use meh-o">&#xf11a</i>
+                                            fa-meh-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mercury">&#xf223</i>
+                                            fa-mercury
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use microphone">&#xf130</i>
+                                            fa-microphone
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use microphone-slash">&#xf131</i>
+                                            fa-microphone-slash
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus">&#xf068</i>
+                                            fa-minus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-circle">&#xf056</i>
+                                            fa-minus-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-square">&#xf146</i>
+                                            fa-minus-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use minus-square-o">&#xf147</i>
+                                            fa-minus-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mixcloud">&#xf289</i>
+                                            fa-mixcloud
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mobile">&#xf10b</i>
+                                            fa-mobile
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mobile-phone">&#xf10b</i>
+                                            fa-mobile-phone
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use modx">&#xf285</i>
+                                            fa-modx
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use money">&#xf0d6</i>
+                                            fa-money
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use moon-o">&#xf186</i>
+                                            fa-moon-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mortar-board">&#xf19d</i>
+                                            fa-mortar-board
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use motorcycle">&#xf21c</i>
+                                            fa-motorcycle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use mouse-pointer">&#xf245</i>
+                                            fa-mouse-pointer
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use music">&#xf001</i>
+                                            fa-music
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use navicon">&#xf0c9</i>
+                                            fa-navicon
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use neuter">&#xf22c</i>
+                                            fa-neuter
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use newspaper-o">&#xf1ea</i>
+                                            fa-newspaper-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use object-group">&#xf247</i>
+                                            fa-object-group
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use object-ungroup">&#xf248</i>
+                                            fa-object-ungroup
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use odnoklassniki">&#xf263</i>
+                                            fa-odnoklassniki
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use odnoklassniki-square">&#xf264</i>
+                                            fa-odnoklassniki-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use opencart">&#xf23d</i>
+                                            fa-opencart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use openid">&#xf19b</i>
+                                            fa-openid
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use opera">&#xf26a</i>
+                                            fa-opera
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use optin-monster">&#xf23c</i>
+                                            fa-optin-monster
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use outdent">&#xf03b</i>
+                                            fa-outdent
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pagelines">&#xf18c</i>
+                                            fa-pagelines
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paint-brush">&#xf1fc</i>
+                                            fa-paint-brush
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paper-plane">&#xf1d8</i>
+                                            fa-paper-plane
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paper-plane-o">&#xf1d9</i>
+                                            fa-paper-plane-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paperclip">&#xf0c6</i>
+                                            fa-paperclip
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paragraph">&#xf1dd</i>
+                                            fa-paragraph
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paste">&#xf0ea</i>
+                                            fa-paste
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause">&#xf04c</i>
+                                            fa-pause
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause-circle">&#xf28b</i>
+                                            fa-pause-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pause-circle-o">&#xf28c</i>
+                                            fa-pause-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paw">&#xf1b0</i>
+                                            fa-paw
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use paypal">&#xf1ed</i>
+                                            fa-paypal
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil">&#xf040</i>
+                                            fa-pencil
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil-square">&#xf14b</i>
+                                            fa-pencil-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pencil-square-o">&#xf044</i>
+                                            fa-pencil-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use percent">&#xf295</i>
+                                            fa-percent
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use phone">&#xf095</i>
+                                            fa-phone
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use phone-square">&#xf098</i>
+                                            fa-phone-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use photo">&#xf03e</i>
+                                            fa-photo
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use picture-o">&#xf03e</i>
+                                            fa-picture-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pie-chart">&#xf200</i>
+                                            fa-pie-chart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper">&#xf2ae</i>
+                                            fa-pied-piper
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper-alt">&#xf1a8</i>
+                                            fa-pied-piper-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pied-piper-pp">&#xf1a7</i>
+                                            fa-pied-piper-pp
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest">&#xf0d2</i>
+                                            fa-pinterest
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest-p">&#xf231</i>
+                                            fa-pinterest-p
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use pinterest-square">&#xf0d3</i>
+                                            fa-pinterest-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plane">&#xf072</i>
+                                            fa-plane
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use play">&#xf04b</i>
+                                            fa-play
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use play-circle">&#xf144</i>
+                                            fa-play-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use play-circle-o">&#xf01d</i>
+                                            fa-play-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plug">&#xf1e6</i>
+                                            fa-plug
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus">&#xf067</i>
+                                            fa-plus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-circle">&#xf055</i>
+                                            fa-plus-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-square">&#xf0fe</i>
+                                            fa-plus-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use plus-square-o">&#xf196</i>
+                                            fa-plus-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use power-off">&#xf011</i>
+                                            fa-power-off
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use print">&#xf02f</i>
+                                            fa-print
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use product-hunt">&#xf288</i>
+                                            fa-product-hunt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use puzzle-piece">&#xf12e</i>
+                                            fa-puzzle-piece
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use qq">&#xf1d6</i>
+                                            fa-qq
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use qrcode">&#xf029</i>
+                                            fa-qrcode
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use question">&#xf128</i>
+                                            fa-question
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use question-circle">&#xf059</i>
+                                            fa-question-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use question-circle-o">&#xf29c</i>
+                                            fa-question-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use quote-left">&#xf10d</i>
+                                            fa-quote-left
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use quote-right">&#xf10e</i>
+                                            fa-quote-right
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ra">&#xf1d0</i>
+                                            fa-ra
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use random">&#xf074</i>
+                                            fa-random
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rebel">&#xf1d0</i>
+                                            fa-rebel
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use recycle">&#xf1b8</i>
+                                            fa-recycle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit">&#xf1a1</i>
+                                            fa-reddit
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit-alien">&#xf281</i>
+                                            fa-reddit-alien
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reddit-square">&#xf1a2</i>
+                                            fa-reddit-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use refresh">&#xf021</i>
+                                            fa-refresh
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use registered">&#xf25d</i>
+                                            fa-registered
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use remove">&#xf00d</i>
+                                            fa-remove
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use renren">&#xf18b</i>
+                                            fa-renren
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reorder">&#xf0c9</i>
+                                            fa-reorder
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use repeat">&#xf01e</i>
+                                            fa-repeat
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reply">&#xf112</i>
+                                            fa-reply
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use reply-all">&#xf122</i>
+                                            fa-reply-all
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use resistance">&#xf1d0</i>
+                                            fa-resistance
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use retweet">&#xf079</i>
+                                            fa-retweet
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rmb">&#xf157</i>
+                                            fa-rmb
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use road">&#xf018</i>
+                                            fa-road
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rocket">&#xf135</i>
+                                            fa-rocket
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rotate-left">&#xf0e2</i>
+                                            fa-rotate-left
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rotate-right">&#xf01e</i>
+                                            fa-rotate-right
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rouble">&#xf158</i>
+                                            fa-rouble
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rss">&#xf09e</i>
+                                            fa-rss
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rss-square">&#xf143</i>
+                                            fa-rss-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rub">&#xf158</i>
+                                            fa-rub
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ruble">&#xf158</i>
+                                            fa-ruble
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use rupee">&#xf156</i>
+                                            fa-rupee
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use safari">&#xf267</i>
+                                            fa-safari
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use save">&#xf0c7</i>
+                                            fa-save
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use scissors">&#xf0c4</i>
+                                            fa-scissors
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use scribd">&#xf28a</i>
+                                            fa-scribd
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use search">&#xf002</i>
+                                            fa-search
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use search-minus">&#xf010</i>
+                                            fa-search-minus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use search-plus">&#xf00e</i>
+                                            fa-search-plus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sellsy">&#xf213</i>
+                                            fa-sellsy
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use send">&#xf1d8</i>
+                                            fa-send
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use send-o">&#xf1d9</i>
+                                            fa-send-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use server">&#xf233</i>
+                                            fa-server
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use share">&#xf064</i>
+                                            fa-share
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-alt">&#xf1e0</i>
+                                            fa-share-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-alt-square">&#xf1e1</i>
+                                            fa-share-alt-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-square">&#xf14d</i>
+                                            fa-share-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use share-square-o">&#xf045</i>
+                                            fa-share-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shekel">&#xf20b</i>
+                                            fa-shekel
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sheqel">&#xf20b</i>
+                                            fa-sheqel
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shield">&#xf132</i>
+                                            fa-shield
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ship">&#xf21a</i>
+                                            fa-ship
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shirtsinbulk">&#xf214</i>
+                                            fa-shirtsinbulk
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-bag">&#xf290</i>
+                                            fa-shopping-bag
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-basket">&#xf291</i>
+                                            fa-shopping-basket
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use shopping-cart">&#xf07a</i>
+                                            fa-shopping-cart
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-in">&#xf090</i>
+                                            fa-sign-in
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-language">&#xf2a7</i>
+                                            fa-sign-language
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sign-out">&#xf08b</i>
+                                            fa-sign-out
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use signal">&#xf012</i>
+                                            fa-signal
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use signing">&#xf2a7</i>
+                                            fa-signing
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use simplybuilt">&#xf215</i>
+                                            fa-simplybuilt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sitemap">&#xf0e8</i>
+                                            fa-sitemap
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use skyatlas">&#xf216</i>
+                                            fa-skyatlas
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use skype">&#xf17e</i>
+                                            fa-skype
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use slack">&#xf198</i>
+                                            fa-slack
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sliders">&#xf1de</i>
+                                            fa-sliders
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use slideshare">&#xf1e7</i>
+                                            fa-slideshare
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use smile-o">&#xf118</i>
+                                            fa-smile-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat">&#xf2ab</i>
+                                            fa-snapchat
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat-ghost">&#xf2ac</i>
+                                            fa-snapchat-ghost
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use snapchat-square">&#xf2ad</i>
+                                            fa-snapchat-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use soccer-ball-o">&#xf1e3</i>
+                                            fa-soccer-ball-o
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort">&#xf0dc</i>
+                                            fa-sort
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-alpha-asc">&#xf15d</i>
+                                            fa-sort-alpha-asc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-alpha-desc">&#xf15e</i>
+                                            fa-sort-alpha-desc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-amount-asc">&#xf160</i>
+                                            fa-sort-amount-asc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-amount-desc">&#xf161</i>
+                                            fa-sort-amount-desc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-asc">&#xf0de</i>
+                                            fa-sort-asc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-desc">&#xf0dd</i>
+                                            fa-sort-desc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-down">&#xf0dd</i>
+                                            fa-sort-down
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-numeric-asc">&#xf162</i>
+                                            fa-sort-numeric-asc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-numeric-desc">&#xf163</i>
+                                            fa-sort-numeric-desc
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sort-up">&#xf0de</i>
+                                            fa-sort-up
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use soundcloud">&#xf1be</i>
+                                            fa-soundcloud
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use space-shuttle">&#xf197</i>
+                                            fa-space-shuttle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use spinner">&#xf110</i>
+                                            fa-spinner
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use spoon">&#xf1b1</i>
+                                            fa-spoon
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use spotify">&#xf1bc</i>
+                                            fa-spotify
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use square">&#xf0c8</i>
+                                            fa-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use square-o">&#xf096</i>
+                                            fa-square-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stack-exchange">&#xf18d</i>
+                                            fa-stack-exchange
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stack-overflow">&#xf16c</i>
+                                            fa-stack-overflow
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star">&#xf005</i>
+                                            fa-star
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half">&#xf089</i>
+                                            fa-star-half
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-empty">&#xf123</i>
+                                            fa-star-half-empty
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-full">&#xf123</i>
+                                            fa-star-half-full
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-half-o">&#xf123</i>
+                                            fa-star-half-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use star-o">&#xf006</i>
+                                            fa-star-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use steam">&#xf1b6</i>
+                                            fa-steam
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use steam-square">&#xf1b7</i>
+                                            fa-steam-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use step-backward">&#xf048</i>
+                                            fa-step-backward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use step-forward">&#xf051</i>
+                                            fa-step-forward
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stethoscope">&#xf0f1</i>
+                                            fa-stethoscope
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sticky-note">&#xf249</i>
+                                            fa-sticky-note
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sticky-note-o">&#xf24a</i>
+                                            fa-sticky-note-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop">&#xf04d</i>
+                                            fa-stop
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop-circle">&#xf28d</i>
+                                            fa-stop-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stop-circle-o">&#xf28e</i>
+                                            fa-stop-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use street-view">&#xf21d</i>
+                                            fa-street-view
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use strikethrough">&#xf0cc</i>
+                                            fa-strikethrough
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stumbleupon">&#xf1a4</i>
+                                            fa-stumbleupon
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use stumbleupon-circle">&#xf1a3</i>
+                                            fa-stumbleupon-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use subscript">&#xf12c</i>
+                                            fa-subscript
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use subway">&#xf239</i>
+                                            fa-subway
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use suitcase">&#xf0f2</i>
+                                            fa-suitcase
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use sun-o">&#xf185</i>
+                                            fa-sun-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use superscript">&#xf12b</i>
+                                            fa-superscript
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use support">&#xf1cd</i>
+                                            fa-support
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use table">&#xf0ce</i>
+                                            fa-table
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tablet">&#xf10a</i>
+                                            fa-tablet
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tachometer">&#xf0e4</i>
+                                            fa-tachometer
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tag">&#xf02b</i>
+                                            fa-tag
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tags">&#xf02c</i>
+                                            fa-tags
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tasks">&#xf0ae</i>
+                                            fa-tasks
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use taxi">&#xf1ba</i>
+                                            fa-taxi
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use television">&#xf26c</i>
+                                            fa-television
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tencent-weibo">&#xf1d5</i>
+                                            fa-tencent-weibo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use terminal">&#xf120</i>
+                                            fa-terminal
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use text-height">&#xf034</i>
+                                            fa-text-height
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use text-width">&#xf035</i>
+                                            fa-text-width
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use th">&#xf00a</i>
+                                            fa-th
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use th-large">&#xf009</i>
+                                            fa-th-large
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use th-list">&#xf00b</i>
+                                            fa-th-list
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use themeisle">&#xf2b2</i>
+                                            fa-themeisle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumb-tack">&#xf08d</i>
+                                            fa-thumb-tack
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-down">&#xf165</i>
+                                            fa-thumbs-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-o-down">&#xf088</i>
+                                            fa-thumbs-o-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-o-up">&#xf087</i>
+                                            fa-thumbs-o-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use thumbs-up">&#xf164</i>
+                                            fa-thumbs-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use ticket">&#xf145</i>
+                                            fa-ticket
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use times">&#xf00d</i>
+                                            fa-times
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use times-circle">&#xf057</i>
+                                            fa-times-circle
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use times-circle-o">&#xf05c</i>
+                                            fa-times-circle-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tint">&#xf043</i>
+                                            fa-tint
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-down">&#xf150</i>
+                                            fa-toggle-down
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-left">&#xf191</i>
+                                            fa-toggle-left
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-off">&#xf204</i>
+                                            fa-toggle-off
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-on">&#xf205</i>
+                                            fa-toggle-on
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-right">&#xf152</i>
+                                            fa-toggle-right
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use toggle-up">&#xf151</i>
+                                            fa-toggle-up
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use trademark">&#xf25c</i>
+                                            fa-trademark
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use train">&#xf238</i>
+                                            fa-train
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use transgender">&#xf224</i>
+                                            fa-transgender
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use transgender-alt">&#xf225</i>
+                                            fa-transgender-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use trash">&#xf1f8</i>
+                                            fa-trash
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use trash-o">&#xf014</i>
+                                            fa-trash-o
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tree">&#xf1bb</i>
+                                            fa-tree
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use trello">&#xf181</i>
+                                            fa-trello
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tripadvisor">&#xf262</i>
+                                            fa-tripadvisor
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use trophy">&#xf091</i>
+                                            fa-trophy
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use truck">&#xf0d1</i>
+                                            fa-truck
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use try">&#xf195</i>
+                                            fa-try
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tty">&#xf1e4</i>
+                                            fa-tty
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tumblr">&#xf173</i>
+                                            fa-tumblr
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tumblr-square">&#xf174</i>
+                                            fa-tumblr-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use turkish-lira">&#xf195</i>
+                                            fa-turkish-lira
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use tv">&#xf26c</i>
+                                            fa-tv
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitch">&#xf1e8</i>
+                                            fa-twitch
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitter">&#xf099</i>
+                                            fa-twitter
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use twitter-square">&#xf081</i>
+                                            fa-twitter-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use umbrella">&#xf0e9</i>
+                                            fa-umbrella
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use underline">&#xf0cd</i>
+                                            fa-underline
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use undo">&#xf0e2</i>
+                                            fa-undo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use universal-access">&#xf29a</i>
+                                            fa-universal-access
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use university">&#xf19c</i>
+                                            fa-university
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlink">&#xf127</i>
+                                            fa-unlink
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlock">&#xf09c</i>
+                                            fa-unlock
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use unlock-alt">&#xf13e</i>
+                                            fa-unlock-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use unsorted">&#xf0dc</i>
+                                            fa-unsorted
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use upload">&#xf093</i>
+                                            fa-upload
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use usb">&#xf287</i>
+                                            fa-usb
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use usd">&#xf155</i>
+                                            fa-usd
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use user">&#xf007</i>
+                                            fa-user
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-md">&#xf0f0</i>
+                                            fa-user-md
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-plus">&#xf234</i>
+                                            fa-user-plus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-secret">&#xf21b</i>
+                                            fa-user-secret
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use user-times">&#xf235</i>
+                                            fa-user-times
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use users">&#xf0c0</i>
+                                            fa-users
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus">&#xf221</i>
+                                            fa-venus
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus-double">&#xf226</i>
+                                            fa-venus-double
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use venus-mars">&#xf228</i>
+                                            fa-venus-mars
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use viacoin">&#xf237</i>
+                                            fa-viacoin
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use viadeo">&#xf2a9</i>
+                                            fa-viadeo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use viadeo-square">&#xf2aa</i>
+                                            fa-viadeo-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use video-camera">&#xf03d</i>
+                                            fa-video-camera
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use vimeo">&#xf27d</i>
+                                            fa-vimeo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use vimeo-square">&#xf194</i>
+                                            fa-vimeo-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use vine">&#xf1ca</i>
+                                            fa-vine
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use vk">&#xf189</i>
+                                            fa-vk
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-control-phone">&#xf2a0</i>
+                                            fa-volume-control-phone
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-down">&#xf027</i>
+                                            fa-volume-down
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-off">&#xf026</i>
+                                            fa-volume-off
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use volume-up">&#xf028</i>
+                                            fa-volume-up
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use warning">&#xf071</i>
+                                            fa-warning
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wechat">&#xf1d7</i>
+                                            fa-wechat
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use weibo">&#xf18a</i>
+                                            fa-weibo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use weixin">&#xf1d7</i>
+                                            fa-weixin
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use whatsapp">&#xf232</i>
+                                            fa-whatsapp
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wheelchair">&#xf193</i>
+                                            fa-wheelchair
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wheelchair-alt">&#xf29b</i>
+                                            fa-wheelchair-alt
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wifi">&#xf1eb</i>
+                                            fa-wifi
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wikipedia-w">&#xf266</i>
+                                            fa-wikipedia-w
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use windows">&#xf17a</i>
+                                            fa-windows
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use won">&#xf159</i>
+                                            fa-won
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wordpress">&#xf19a</i>
+                                            fa-wordpress
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wpbeginner">&#xf297</i>
+                                            fa-wpbeginner
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wpforms">&#xf298</i>
+                                            fa-wpforms
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use wrench">&#xf0ad</i>
+                                            fa-wrench
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use xing">&#xf168</i>
+                                            fa-xing
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use xing-square">&#xf169</i>
+                                            fa-xing-square
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use y-combinator">&#xf23b</i>
+                                            fa-y-combinator
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use y-combinator-square">&#xf1d4</i>
+                                            fa-y-combinator-square
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yahoo">&#xf19e</i>
+                                            fa-yahoo
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yc">&#xf23b</i>
+                                            fa-yc
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yc-square">&#xf1d4</i>
+                                            fa-yc-square
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yelp">&#xf1e9</i>
+                                            fa-yelp
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yen">&#xf157</i>
+                                            fa-yen
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use yoast">&#xf2b1</i>
+                                            fa-yoast
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube">&#xf167</i>
+                                            fa-youtube
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube-play">&#xf16a</i>
+                                            fa-youtube-play
+
+                                        </div>
+
+                                        <div class="col-md-4 col-sm-6 col-lg-3">
+
+                                            <i class="fa fa-fw" aria-hidden="true" title="Copy to use youtube-square">&#xf166</i>
+                                            fa-youtube-square
+
+                                        </div>
+
+                                    </div>
+                                    <!-- /.row (nested) -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
-
         </div>
         <!-- /#wrapper -->
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -234,607 +234,610 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Dashboard</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Dashboard</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-3 col-md-6">
-                        <div class="panel panel-primary">
-                            <div class="panel-heading">
-                                <div class="row">
-                                    <div class="col-xs-3">
-                                        <i class="fa fa-comments fa-5x"></i>
-                                    </div>
-                                    <div class="col-xs-9 text-right">
-                                        <div class="huge">26</div>
-                                        <div>New Comments!</div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-3 col-md-6">
+                            <div class="panel panel-primary">
+                                <div class="panel-heading">
+                                    <div class="row">
+                                        <div class="col-xs-3">
+                                            <i class="fa fa-comments fa-5x"></i>
+                                        </div>
+                                        <div class="col-xs-9 text-right">
+                                            <div class="huge">26</div>
+                                            <div>New Comments!</div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                            <a href="#">
-                                <div class="panel-footer">
-                                    <span class="pull-left">View Details</span>
-                                    <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
+                                <a href="#">
+                                    <div class="panel-footer">
+                                        <span class="pull-left">View Details</span>
+                                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
 
-                                    <div class="clearfix"></div>
+                                        <div class="clearfix"></div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="panel panel-green">
+                                <div class="panel-heading">
+                                    <div class="row">
+                                        <div class="col-xs-3">
+                                            <i class="fa fa-tasks fa-5x"></i>
+                                        </div>
+                                        <div class="col-xs-9 text-right">
+                                            <div class="huge">12</div>
+                                            <div>New Tasks!</div>
+                                        </div>
+                                    </div>
                                 </div>
-                            </a>
+                                <a href="#">
+                                    <div class="panel-footer">
+                                        <span class="pull-left">View Details</span>
+                                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
+
+                                        <div class="clearfix"></div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="panel panel-yellow">
+                                <div class="panel-heading">
+                                    <div class="row">
+                                        <div class="col-xs-3">
+                                            <i class="fa fa-shopping-cart fa-5x"></i>
+                                        </div>
+                                        <div class="col-xs-9 text-right">
+                                            <div class="huge">124</div>
+                                            <div>New Orders!</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <a href="#">
+                                    <div class="panel-footer">
+                                        <span class="pull-left">View Details</span>
+                                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
+
+                                        <div class="clearfix"></div>
+                                    </div>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="col-lg-3 col-md-6">
+                            <div class="panel panel-red">
+                                <div class="panel-heading">
+                                    <div class="row">
+                                        <div class="col-xs-3">
+                                            <i class="fa fa-support fa-5x"></i>
+                                        </div>
+                                        <div class="col-xs-9 text-right">
+                                            <div class="huge">13</div>
+                                            <div>Support Tickets!</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <a href="#">
+                                    <div class="panel-footer">
+                                        <span class="pull-left">View Details</span>
+                                        <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
+
+                                        <div class="clearfix"></div>
+                                    </div>
+                                </a>
+                            </div>
                         </div>
                     </div>
-                    <div class="col-lg-3 col-md-6">
-                        <div class="panel panel-green">
-                            <div class="panel-heading">
-                                <div class="row">
-                                    <div class="col-xs-3">
-                                        <i class="fa fa-tasks fa-5x"></i>
-                                    </div>
-                                    <div class="col-xs-9 text-right">
-                                        <div class="huge">12</div>
-                                        <div>New Tasks!</div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-8">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-bar-chart-o fa-fw"></i> Area Chart Example
+                                    <div class="pull-right">
+                                        <div class="btn-group">
+                                            <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                                                    data-toggle="dropdown">
+                                                Actions
+                                                <span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu pull-right" role="menu">
+                                                <li><a href="#">Action</a>
+                                                </li>
+                                                <li><a href="#">Another action</a>
+                                                </li>
+                                                <li><a href="#">Something else here</a>
+                                                </li>
+                                                <li class="divider"></li>
+                                                <li><a href="#">Separated link</a>
+                                                </li>
+                                            </ul>
+                                        </div>
                                     </div>
                                 </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div id="morris-area-chart"></div>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <a href="#">
-                                <div class="panel-footer">
-                                    <span class="pull-left">View Details</span>
-                                    <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
+                            <!-- /.panel -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-bar-chart-o fa-fw"></i> Bar Chart Example
+                                    <div class="pull-right">
+                                        <div class="btn-group">
+                                            <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                                                    data-toggle="dropdown">
+                                                Actions
+                                                <span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu pull-right" role="menu">
+                                                <li><a href="#">Action</a>
+                                                </li>
+                                                <li><a href="#">Another action</a>
+                                                </li>
+                                                <li><a href="#">Something else here</a>
+                                                </li>
+                                                <li class="divider"></li>
+                                                <li><a href="#">Separated link</a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="row">
+                                        <div class="col-lg-4">
+                                            <div class="table-responsive">
+                                                <table class="table table-bordered table-hover table-striped">
+                                                    <thead>
+                                                    <tr>
+                                                        <th>#</th>
+                                                        <th>Date</th>
+                                                        <th>Time</th>
+                                                        <th>Amount</th>
+                                                    </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                    <tr>
+                                                        <td>3326</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>3:29 PM</td>
+                                                        <td>$321.33</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3325</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>3:20 PM</td>
+                                                        <td>$234.34</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3324</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>3:03 PM</td>
+                                                        <td>$724.17</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3323</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>3:00 PM</td>
+                                                        <td>$23.71</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3322</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>2:49 PM</td>
+                                                        <td>$8345.23</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3321</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>2:23 PM</td>
+                                                        <td>$245.12</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3320</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>2:15 PM</td>
+                                                        <td>$5663.54</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td>3319</td>
+                                                        <td>10/21/2013</td>
+                                                        <td>2:13 PM</td>
+                                                        <td>$943.45</td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                            <!-- /.table-responsive -->
+                                        </div>
+                                        <!-- /.col-lg-4 (nested) -->
+                                        <div class="col-lg-8">
+                                            <div id="morris-bar-chart"></div>
+                                        </div>
+                                        <!-- /.col-lg-8 (nested) -->
+                                    </div>
+                                    <!-- /.row -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-clock-o fa-fw"></i> Responsive Timeline
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <ul class="timeline">
+                                        <li>
+                                            <div class="timeline-badge"><i class="fa fa-check"></i>
+                                            </div>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
 
-                                    <div class="clearfix"></div>
-                                </div>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="col-lg-3 col-md-6">
-                        <div class="panel panel-yellow">
-                            <div class="panel-heading">
-                                <div class="row">
-                                    <div class="col-xs-3">
-                                        <i class="fa fa-shopping-cart fa-5x"></i>
-                                    </div>
-                                    <div class="col-xs-9 text-right">
-                                        <div class="huge">124</div>
-                                        <div>New Orders!</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <a href="#">
-                                <div class="panel-footer">
-                                    <span class="pull-left">View Details</span>
-                                    <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
-
-                                    <div class="clearfix"></div>
-                                </div>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="col-lg-3 col-md-6">
-                        <div class="panel panel-red">
-                            <div class="panel-heading">
-                                <div class="row">
-                                    <div class="col-xs-3">
-                                        <i class="fa fa-support fa-5x"></i>
-                                    </div>
-                                    <div class="col-xs-9 text-right">
-                                        <div class="huge">13</div>
-                                        <div>Support Tickets!</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <a href="#">
-                                <div class="panel-footer">
-                                    <span class="pull-left">View Details</span>
-                                    <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>
-
-                                    <div class="clearfix"></div>
-                                </div>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-8">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-bar-chart-o fa-fw"></i> Area Chart Example
-                                <div class="pull-right">
-                                    <div class="btn-group">
-                                        <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                                                data-toggle="dropdown">
-                                            Actions
-                                            <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu pull-right" role="menu">
-                                            <li><a href="#">Action</a>
-                                            </li>
-                                            <li><a href="#">Another action</a>
-                                            </li>
-                                            <li><a href="#">Something else here</a>
-                                            </li>
-                                            <li class="divider"></li>
-                                            <li><a href="#">Separated link</a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div id="morris-area-chart"></div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-bar-chart-o fa-fw"></i> Bar Chart Example
-                                <div class="pull-right">
-                                    <div class="btn-group">
-                                        <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                                                data-toggle="dropdown">
-                                            Actions
-                                            <span class="caret"></span>
-                                        </button>
-                                        <ul class="dropdown-menu pull-right" role="menu">
-                                            <li><a href="#">Action</a>
-                                            </li>
-                                            <li><a href="#">Another action</a>
-                                            </li>
-                                            <li><a href="#">Something else here</a>
-                                            </li>
-                                            <li class="divider"></li>
-                                            <li><a href="#">Separated link</a>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="row">
-                                    <div class="col-lg-4">
-                                        <div class="table-responsive">
-                                            <table class="table table-bordered table-hover table-striped">
-                                                <thead>
-                                                <tr>
-                                                    <th>#</th>
-                                                    <th>Date</th>
-                                                    <th>Time</th>
-                                                    <th>Amount</th>
-                                                </tr>
-                                                </thead>
-                                                <tbody>
-                                                <tr>
-                                                    <td>3326</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>3:29 PM</td>
-                                                    <td>$321.33</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3325</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>3:20 PM</td>
-                                                    <td>$234.34</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3324</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>3:03 PM</td>
-                                                    <td>$724.17</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3323</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>3:00 PM</td>
-                                                    <td>$23.71</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3322</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>2:49 PM</td>
-                                                    <td>$8345.23</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3321</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>2:23 PM</td>
-                                                    <td>$245.12</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3320</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>2:15 PM</td>
-                                                    <td>$5663.54</td>
-                                                </tr>
-                                                <tr>
-                                                    <td>3319</td>
-                                                    <td>10/21/2013</td>
-                                                    <td>2:13 PM</td>
-                                                    <td>$943.45</td>
-                                                </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                        <!-- /.table-responsive -->
-                                    </div>
-                                    <!-- /.col-lg-4 (nested) -->
-                                    <div class="col-lg-8">
-                                        <div id="morris-bar-chart"></div>
-                                    </div>
-                                    <!-- /.col-lg-8 (nested) -->
-                                </div>
-                                <!-- /.row -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-clock-o fa-fw"></i> Responsive Timeline
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <ul class="timeline">
-                                    <li>
-                                        <div class="timeline-badge"><i class="fa fa-check"></i>
-                                        </div>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-
-                                                <p>
-                                                    <small class="text-muted"><i class="fa fa-clock-o"></i> 11 hours ago via
-                                                        Twitter
-                                                    </small>
-                                                </p>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Libero
-                                                    laboriosam
-                                                    dolor perspiciatis omnis exercitationem. Beatae, officia pariatur? Est
-                                                    cum
-                                                    veniam excepturi. Maiores praesentium, porro voluptas suscipit facere
-                                                    rem
-                                                    dicta, debitis.</p>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <li class="timeline-inverted">
-                                        <div class="timeline-badge warning"><i class="fa fa-credit-card"></i>
-                                        </div>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem dolorem
-                                                    quibusdam, tenetur commodi provident cumque magni voluptatem libero,
-                                                    quis
-                                                    rerum. Fugiat esse debitis optio, tempore. Animi officiis alias, officia
-                                                    repellendus.</p>
-
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Laudantium
-                                                    maiores
-                                                    odit qui est tempora eos, nostrum provident explicabo dignissimos
-                                                    debitis
-                                                    vel! Adipisci eius voluptates, ad aut recusandae minus eaque facere.</p>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <li>
-                                        <div class="timeline-badge danger"><i class="fa fa-bomb"></i>
-                                        </div>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repellendus
-                                                    numquam
-                                                    facilis enim eaque, tenetur nam id qui vel velit similique nihil iure
-                                                    molestias aliquam, voluptatem totam quaerat, magni commodi quisquam.</p>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <li class="timeline-inverted">
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptates est
-                                                    quaerat asperiores sapiente, eligendi, nihil. Itaque quos, alias
-                                                    sapiente
-                                                    rerum quas odit! Aperiam officiis quidem delectus libero, omnis ut
-                                                    debitis!</p>
-                                            </div>
-                                        </div>
-                                    </li>
-                                    <li>
-                                        <div class="timeline-badge info"><i class="fa fa-save"></i>
-                                        </div>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nobis minus
-                                                    modi
-                                                    quam ipsum alias at est molestiae excepturi delectus nesciunt, quibusdam
-                                                    debitis amet, beatae consequuntur impedit nulla qui! Laborum, atque.</p>
-                                                <hr>
-                                                <div class="btn-group">
-                                                    <button type="button" class="btn btn-primary btn-sm dropdown-toggle"
-                                                            data-toggle="dropdown">
-                                                        <i class="fa fa-gear"></i> <span class="caret"></span>
-                                                    </button>
-                                                    <ul class="dropdown-menu" role="menu">
-                                                        <li><a href="#">Action</a>
-                                                        </li>
-                                                        <li><a href="#">Another action</a>
-                                                        </li>
-                                                        <li><a href="#">Something else here</a>
-                                                        </li>
-                                                        <li class="divider"></li>
-                                                        <li><a href="#">Separated link</a>
-                                                        </li>
-                                                    </ul>
+                                                    <p>
+                                                        <small class="text-muted"><i class="fa fa-clock-o"></i> 11 hours ago via
+                                                            Twitter
+                                                        </small>
+                                                    </p>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Libero
+                                                        laboriosam
+                                                        dolor perspiciatis omnis exercitationem. Beatae, officia pariatur? Est
+                                                        cum
+                                                        veniam excepturi. Maiores praesentium, porro voluptas suscipit facere
+                                                        rem
+                                                        dicta, debitis.</p>
                                                 </div>
                                             </div>
-                                        </div>
-                                    </li>
-                                    <li>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                        </li>
+                                        <li class="timeline-inverted">
+                                            <div class="timeline-badge warning"><i class="fa fa-credit-card"></i>
                                             </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sequi fuga odio
-                                                    quibusdam. Iure expedita, incidunt unde quis nam! Quod, quisquam.
-                                                    Officia
-                                                    quam qui adipisci quas consequuntur nostrum sequi. Consequuntur,
-                                                    commodi.</p>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Autem dolorem
+                                                        quibusdam, tenetur commodi provident cumque magni voluptatem libero,
+                                                        quis
+                                                        rerum. Fugiat esse debitis optio, tempore. Animi officiis alias, officia
+                                                        repellendus.</p>
+
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Laudantium
+                                                        maiores
+                                                        odit qui est tempora eos, nostrum provident explicabo dignissimos
+                                                        debitis
+                                                        vel! Adipisci eius voluptates, ad aut recusandae minus eaque facere.</p>
+                                                </div>
                                             </div>
-                                        </div>
-                                    </li>
-                                    <li class="timeline-inverted">
-                                        <div class="timeline-badge success"><i class="fa fa-graduation-cap"></i>
-                                        </div>
-                                        <div class="timeline-panel">
-                                            <div class="timeline-heading">
-                                                <h4 class="timeline-title">Lorem ipsum dolor</h4>
-                                            </div>
-                                            <div class="timeline-body">
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Deserunt
-                                                    obcaecati,
-                                                    quaerat tempore officia voluptas debitis consectetur culpa amet,
-                                                    accusamus
-                                                    dolorum fugiat, animi dicta aperiam, enim incidunt quisquam maxime neque
-                                                    eaque.</p>
-                                            </div>
-                                        </div>
-                                    </li>
-                                </ul>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-8 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-bell fa-fw"></i> Notifications Panel
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="list-group">
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-comment fa-fw"></i> New Comment
-                                            <span class="pull-right text-muted small"><em>4 minutes ago</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-twitter fa-fw"></i> 3 New Followers
-                                            <span class="pull-right text-muted small"><em>12 minutes ago</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-envelope fa-fw"></i> Message Sent
-                                            <span class="pull-right text-muted small"><em>27 minutes ago</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-tasks fa-fw"></i> New Task
-                                            <span class="pull-right text-muted small"><em>43 minutes ago</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-upload fa-fw"></i> Server Rebooted
-                                            <span class="pull-right text-muted small"><em>11:32 AM</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-bolt fa-fw"></i> Server Crashed!
-                                            <span class="pull-right text-muted small"><em>11:13 AM</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-warning fa-fw"></i> Server Not Responding
-                                            <span class="pull-right text-muted small"><em>10:57 AM</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-shopping-cart fa-fw"></i> New Order Placed
-                                            <span class="pull-right text-muted small"><em>9:49 AM</em>
-                                            </span>
-                                    </a>
-                                    <a href="#" class="list-group-item">
-                                        <i class="fa fa-money fa-fw"></i> Payment Received
-                                            <span class="pull-right text-muted small"><em>Yesterday</em>
-                                            </span>
-                                    </a>
-                                </div>
-                                <!-- /.list-group -->
-                                <a href="#" class="btn btn-default btn-block">View All Alerts</a>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-bar-chart-o fa-fw"></i> Donut Chart Example
-                            </div>
-                            <div class="panel-body">
-                                <div id="morris-donut-chart"></div>
-                                <a href="#" class="btn btn-default btn-block">View Details</a>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                        <div class="chat-panel panel panel-default">
-                            <div class="panel-heading">
-                                <i class="fa fa-comments fa-fw"></i>
-                                Chat
-                                <div class="btn-group pull-right">
-                                    <button type="button" class="btn btn-default btn-xs dropdown-toggle"
-                                            data-toggle="dropdown">
-                                        <i class="fa fa-chevron-down"></i>
-                                    </button>
-                                    <ul class="dropdown-menu slidedown">
-                                        <li>
-                                            <a href="#">
-                                                <i class="fa fa-refresh fa-fw"></i> Refresh
-                                            </a>
                                         </li>
                                         <li>
-                                            <a href="#">
-                                                <i class="fa fa-check-circle fa-fw"></i> Available
-                                            </a>
+                                            <div class="timeline-badge danger"><i class="fa fa-bomb"></i>
+                                            </div>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Repellendus
+                                                        numquam
+                                                        facilis enim eaque, tenetur nam id qui vel velit similique nihil iure
+                                                        molestias aliquam, voluptatem totam quaerat, magni commodi quisquam.</p>
+                                                </div>
+                                            </div>
+                                        </li>
+                                        <li class="timeline-inverted">
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptates est
+                                                        quaerat asperiores sapiente, eligendi, nihil. Itaque quos, alias
+                                                        sapiente
+                                                        rerum quas odit! Aperiam officiis quidem delectus libero, omnis ut
+                                                        debitis!</p>
+                                                </div>
+                                            </div>
                                         </li>
                                         <li>
-                                            <a href="#">
-                                                <i class="fa fa-times fa-fw"></i> Busy
-                                            </a>
+                                            <div class="timeline-badge info"><i class="fa fa-save"></i>
+                                            </div>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Nobis minus
+                                                        modi
+                                                        quam ipsum alias at est molestiae excepturi delectus nesciunt, quibusdam
+                                                        debitis amet, beatae consequuntur impedit nulla qui! Laborum, atque.</p>
+                                                    <hr>
+                                                    <div class="btn-group">
+                                                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle"
+                                                                data-toggle="dropdown">
+                                                            <i class="fa fa-gear"></i> <span class="caret"></span>
+                                                        </button>
+                                                        <ul class="dropdown-menu" role="menu">
+                                                            <li><a href="#">Action</a>
+                                                            </li>
+                                                            <li><a href="#">Another action</a>
+                                                            </li>
+                                                            <li><a href="#">Something else here</a>
+                                                            </li>
+                                                            <li class="divider"></li>
+                                                            <li><a href="#">Separated link</a>
+                                                            </li>
+                                                        </ul>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </li>
                                         <li>
-                                            <a href="#">
-                                                <i class="fa fa-clock-o fa-fw"></i> Away
-                                            </a>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sequi fuga odio
+                                                        quibusdam. Iure expedita, incidunt unde quis nam! Quod, quisquam.
+                                                        Officia
+                                                        quam qui adipisci quas consequuntur nostrum sequi. Consequuntur,
+                                                        commodi.</p>
+                                                </div>
+                                            </div>
                                         </li>
-                                        <li class="divider"></li>
-                                        <li>
-                                            <a href="#">
-                                                <i class="fa fa-sign-out fa-fw"></i> Sign Out
-                                            </a>
+                                        <li class="timeline-inverted">
+                                            <div class="timeline-badge success"><i class="fa fa-graduation-cap"></i>
+                                            </div>
+                                            <div class="timeline-panel">
+                                                <div class="timeline-heading">
+                                                    <h4 class="timeline-title">Lorem ipsum dolor</h4>
+                                                </div>
+                                                <div class="timeline-body">
+                                                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Deserunt
+                                                        obcaecati,
+                                                        quaerat tempore officia voluptas debitis consectetur culpa amet,
+                                                        accusamus
+                                                        dolorum fugiat, animi dicta aperiam, enim incidunt quisquam maxime neque
+                                                        eaque.</p>
+                                                </div>
+                                            </div>
                                         </li>
                                     </ul>
                                 </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <ul class="chat">
-                                    <li class="left clearfix">
-                                            <span class="chat-img pull-left">
-                                                <img src="http://placehold.it/50/55C1E7/fff" alt="User Avatar"
-                                                     class="img-circle"/>
-                                            </span>
-
-                                        <div class="chat-body clearfix">
-                                            <div class="header">
-                                                <strong class="primary-font">Jack Sparrow</strong>
-                                                <small class="pull-right text-muted">
-                                                    <i class="fa fa-clock-o fa-fw"></i> 12 mins ago
-                                                </small>
-                                            </div>
-                                            <p>
-                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
-                                                ornare dolor, quis ullamcorper ligula sodales.
-                                            </p>
-                                        </div>
-                                    </li>
-                                    <li class="right clearfix">
-                                            <span class="chat-img pull-right">
-                                                <img src="http://placehold.it/50/FA6F57/fff" alt="User Avatar"
-                                                     class="img-circle"/>
-                                            </span>
-
-                                        <div class="chat-body clearfix">
-                                            <div class="header">
-                                                <small class=" text-muted">
-                                                    <i class="fa fa-clock-o fa-fw"></i> 13 mins ago
-                                                </small>
-                                                <strong class="pull-right primary-font">Bhaumik Patel</strong>
-                                            </div>
-                                            <p>
-                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
-                                                ornare dolor, quis ullamcorper ligula sodales.
-                                            </p>
-                                        </div>
-                                    </li>
-                                    <li class="left clearfix">
-                                            <span class="chat-img pull-left">
-                                                <img src="http://placehold.it/50/55C1E7/fff" alt="User Avatar"
-                                                     class="img-circle"/>
-                                            </span>
-
-                                        <div class="chat-body clearfix">
-                                            <div class="header">
-                                                <strong class="primary-font">Jack Sparrow</strong>
-                                                <small class="pull-right text-muted">
-                                                    <i class="fa fa-clock-o fa-fw"></i> 14 mins ago
-                                                </small>
-                                            </div>
-                                            <p>
-                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
-                                                ornare dolor, quis ullamcorper ligula sodales.
-                                            </p>
-                                        </div>
-                                    </li>
-                                    <li class="right clearfix">
-                                            <span class="chat-img pull-right">
-                                                <img src="http://placehold.it/50/FA6F57/fff" alt="User Avatar"
-                                                     class="img-circle"/>
-                                            </span>
-
-                                        <div class="chat-body clearfix">
-                                            <div class="header">
-                                                <small class=" text-muted">
-                                                    <i class="fa fa-clock-o fa-fw"></i> 15 mins ago
-                                                </small>
-                                                <strong class="pull-right primary-font">Bhaumik Patel</strong>
-                                            </div>
-                                            <p>
-                                                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
-                                                ornare dolor, quis ullamcorper ligula sodales.
-                                            </p>
-                                        </div>
-                                    </li>
-                                </ul>
-                            </div>
-                            <!-- /.panel-body -->
-                            <div class="panel-footer">
-                                <div class="input-group">
-                                    <input id="btn-input" type="text" class="form-control input-sm"
-                                           placeholder="Type your message here..."/>
-                                        <span class="input-group-btn">
-                                            <button class="btn btn-warning btn-sm" id="btn-chat">
-                                                Send
-                                            </button>
-                                        </span>
-                                </div>
-                            </div>
-                            <!-- /.panel-footer -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel .chat-panel -->
+                        <!-- /.col-lg-8 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-bell fa-fw"></i> Notifications Panel
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="list-group">
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-comment fa-fw"></i> New Comment
+                                                <span class="pull-right text-muted small"><em>4 minutes ago</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-twitter fa-fw"></i> 3 New Followers
+                                                <span class="pull-right text-muted small"><em>12 minutes ago</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-envelope fa-fw"></i> Message Sent
+                                                <span class="pull-right text-muted small"><em>27 minutes ago</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-tasks fa-fw"></i> New Task
+                                                <span class="pull-right text-muted small"><em>43 minutes ago</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-upload fa-fw"></i> Server Rebooted
+                                                <span class="pull-right text-muted small"><em>11:32 AM</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-bolt fa-fw"></i> Server Crashed!
+                                                <span class="pull-right text-muted small"><em>11:13 AM</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-warning fa-fw"></i> Server Not Responding
+                                                <span class="pull-right text-muted small"><em>10:57 AM</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-shopping-cart fa-fw"></i> New Order Placed
+                                                <span class="pull-right text-muted small"><em>9:49 AM</em>
+                                                </span>
+                                        </a>
+                                        <a href="#" class="list-group-item">
+                                            <i class="fa fa-money fa-fw"></i> Payment Received
+                                                <span class="pull-right text-muted small"><em>Yesterday</em>
+                                                </span>
+                                        </a>
+                                    </div>
+                                    <!-- /.list-group -->
+                                    <a href="#" class="btn btn-default btn-block">View All Alerts</a>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-bar-chart-o fa-fw"></i> Donut Chart Example
+                                </div>
+                                <div class="panel-body">
+                                    <div id="morris-donut-chart"></div>
+                                    <a href="#" class="btn btn-default btn-block">View Details</a>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                            <div class="chat-panel panel panel-default">
+                                <div class="panel-heading">
+                                    <i class="fa fa-comments fa-fw"></i>
+                                    Chat
+                                    <div class="btn-group pull-right">
+                                        <button type="button" class="btn btn-default btn-xs dropdown-toggle"
+                                                data-toggle="dropdown">
+                                            <i class="fa fa-chevron-down"></i>
+                                        </button>
+                                        <ul class="dropdown-menu slidedown">
+                                            <li>
+                                                <a href="#">
+                                                    <i class="fa fa-refresh fa-fw"></i> Refresh
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="#">
+                                                    <i class="fa fa-check-circle fa-fw"></i> Available
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="#">
+                                                    <i class="fa fa-times fa-fw"></i> Busy
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a href="#">
+                                                    <i class="fa fa-clock-o fa-fw"></i> Away
+                                                </a>
+                                            </li>
+                                            <li class="divider"></li>
+                                            <li>
+                                                <a href="#">
+                                                    <i class="fa fa-sign-out fa-fw"></i> Sign Out
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <ul class="chat">
+                                        <li class="left clearfix">
+                                                <span class="chat-img pull-left">
+                                                    <img src="http://placehold.it/50/55C1E7/fff" alt="User Avatar"
+                                                         class="img-circle"/>
+                                                </span>
+
+                                            <div class="chat-body clearfix">
+                                                <div class="header">
+                                                    <strong class="primary-font">Jack Sparrow</strong>
+                                                    <small class="pull-right text-muted">
+                                                        <i class="fa fa-clock-o fa-fw"></i> 12 mins ago
+                                                    </small>
+                                                </div>
+                                                <p>
+                                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
+                                                    ornare dolor, quis ullamcorper ligula sodales.
+                                                </p>
+                                            </div>
+                                        </li>
+                                        <li class="right clearfix">
+                                                <span class="chat-img pull-right">
+                                                    <img src="http://placehold.it/50/FA6F57/fff" alt="User Avatar"
+                                                         class="img-circle"/>
+                                                </span>
+
+                                            <div class="chat-body clearfix">
+                                                <div class="header">
+                                                    <small class=" text-muted">
+                                                        <i class="fa fa-clock-o fa-fw"></i> 13 mins ago
+                                                    </small>
+                                                    <strong class="pull-right primary-font">Bhaumik Patel</strong>
+                                                </div>
+                                                <p>
+                                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
+                                                    ornare dolor, quis ullamcorper ligula sodales.
+                                                </p>
+                                            </div>
+                                        </li>
+                                        <li class="left clearfix">
+                                                <span class="chat-img pull-left">
+                                                    <img src="http://placehold.it/50/55C1E7/fff" alt="User Avatar"
+                                                         class="img-circle"/>
+                                                </span>
+
+                                            <div class="chat-body clearfix">
+                                                <div class="header">
+                                                    <strong class="primary-font">Jack Sparrow</strong>
+                                                    <small class="pull-right text-muted">
+                                                        <i class="fa fa-clock-o fa-fw"></i> 14 mins ago
+                                                    </small>
+                                                </div>
+                                                <p>
+                                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
+                                                    ornare dolor, quis ullamcorper ligula sodales.
+                                                </p>
+                                            </div>
+                                        </li>
+                                        <li class="right clearfix">
+                                                <span class="chat-img pull-right">
+                                                    <img src="http://placehold.it/50/FA6F57/fff" alt="User Avatar"
+                                                         class="img-circle"/>
+                                                </span>
+
+                                            <div class="chat-body clearfix">
+                                                <div class="header">
+                                                    <small class=" text-muted">
+                                                        <i class="fa fa-clock-o fa-fw"></i> 15 mins ago
+                                                    </small>
+                                                    <strong class="pull-right primary-font">Bhaumik Patel</strong>
+                                                </div>
+                                                <p>
+                                                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur bibendum
+                                                    ornare dolor, quis ullamcorper ligula sodales.
+                                                </p>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <!-- /.panel-body -->
+                                <div class="panel-footer">
+                                    <div class="input-group">
+                                        <input id="btn-input" type="text" class="form-control input-sm"
+                                               placeholder="Type your message here..."/>
+                                            <span class="input-group-btn">
+                                                <button class="btn btn-warning btn-sm" id="btn-chat">
+                                                    Send
+                                                </button>
+                                            </span>
+                                    </div>
+                                </div>
+                                <!-- /.panel-footer -->
+                            </div>
+                            <!-- /.panel .chat-panel -->
+                        </div>
+                        <!-- /.col-lg-4 -->
                     </div>
-                    <!-- /.col-lg-4 -->
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/morris.html
+++ b/pages/morris.html
@@ -233,87 +233,90 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Morris.js Charts</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Morris.js Charts</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Area Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div id="morris-area-chart"></div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Bar Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div id="morris-bar-chart"></div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Line Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div id="morris-line-chart"></div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Donut Chart Example
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div id="morris-donut-chart"></div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Morris.js Usage
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <p>Morris.js is a jQuery based charting plugin created by Olly Smith. In SB Admin, we are using the most recent version of Morris.js which includes the resize function, which makes the charts fully responsive. The documentation for Morris.js is available on their website, <a target="_blank" href="http://morrisjs.github.io/morris.js/">http://morrisjs.github.io/morris.js/</a>.</p>
+                                    <a target="_blank" class="btn btn-default btn-lg btn-block" href="http://morrisjs.github.io/morris.js/">View Morris.js Documentation</a>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Area Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div id="morris-area-chart"></div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Bar Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div id="morris-bar-chart"></div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Line Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div id="morris-line-chart"></div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Donut Chart Example
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div id="morris-donut-chart"></div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Morris.js Usage
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <p>Morris.js is a jQuery based charting plugin created by Olly Smith. In SB Admin, we are using the most recent version of Morris.js which includes the resize function, which makes the charts fully responsive. The documentation for Morris.js is available on their website, <a target="_blank" href="http://morrisjs.github.io/morris.js/">http://morrisjs.github.io/morris.js/</a>.</p>
-                                <a target="_blank" class="btn btn-default btn-lg btn-block" href="http://morrisjs.github.io/morris.js/">View Morris.js Documentation</a>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/notifications.html
+++ b/pages/notifications.html
@@ -230,147 +230,150 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Notifications</h1>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Alert Styles
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="alert alert-success">
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                                <div class="alert alert-info">
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                                <div class="alert alert-warning">
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                                <div class="alert alert-danger">
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                            </div>
-                            <!-- .panel-body -->
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Notifications</h1>
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Dismissible Alerts
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="alert alert-success alert-dismissible">
-                                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Alert Styles
                                 </div>
-                                <div class="alert alert-info alert-dismissible">
-                                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                                <div class="alert alert-warning alert-dismissible">
-                                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                                <div class="alert alert-danger alert-dismissible">
-                                    <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
-                                </div>
-                            </div>
-                            <!-- .panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Modals
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <!-- Button trigger modal -->
-                                <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
-                                    Launch Demo Modal
-                                </button>
-                                <!-- Modal -->
-                                <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-                                    <div class="modal-dialog" role="document">
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                                <h4 class="modal-title" id="myModalLabel">Modal title</h4>
-                                            </div>
-                                            <div class="modal-body">
-                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-                                            </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                                                <button type="button" class="btn btn-primary">Save changes</button>
-                                            </div>
-                                        </div>
-                                        <!-- /.modal-content -->
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="alert alert-success">
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
                                     </div>
-                                    <!-- /.modal-dialog -->
+                                    <div class="alert alert-info">
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
+                                    <div class="alert alert-warning">
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
+                                    <div class="alert alert-danger">
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
                                 </div>
-                                <!-- /.modal -->
+                                <!-- .panel-body -->
                             </div>
-                            <!-- .panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Tooltips and Popovers
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <h4>Tooltip Demo</h4>
-                                <div class="tooltip-demo">
-                                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button>
-                                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button>
-                                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
-                                    <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Dismissible Alerts
                                 </div>
-                                <br>
-                                <h4>Clickable Popover Demo</h4>
-                                <div class="tooltip-demo">
-                                    <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="left" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-                                        Popover on left
-                                    </button>
-                                    <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="top" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-                                        Popover on top
-                                    </button>
-                                    <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="bottom" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-                                        Popover on bottom
-                                    </button>
-                                    <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="right" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
-                                        Popover on right
-                                    </button>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="alert alert-success alert-dismissible">
+                                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
+                                    <div class="alert alert-info alert-dismissible">
+                                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
+                                    <div class="alert alert-warning alert-dismissible">
+                                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
+                                    <div class="alert alert-danger alert-dismissible">
+                                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                                        Lorem ipsum dolor sit amet, consectetur adipisicing elit. <a href="#" class="alert-link">Alert Link</a>.
+                                    </div>
                                 </div>
+                                <!-- .panel-body -->
                             </div>
-                            <!-- .panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-6 -->
                     </div>
-                    <!-- /.col-lg-6 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Modals
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <!-- Button trigger modal -->
+                                    <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#myModal">
+                                        Launch Demo Modal
+                                    </button>
+                                    <!-- Modal -->
+                                    <div class="modal fade" id="myModal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+                                        <div class="modal-dialog" role="document">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                                                    <h4 class="modal-title" id="myModalLabel">Modal title</h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                                    <button type="button" class="btn btn-primary">Save changes</button>
+                                                </div>
+                                            </div>
+                                            <!-- /.modal-content -->
+                                        </div>
+                                        <!-- /.modal-dialog -->
+                                    </div>
+                                    <!-- /.modal -->
+                                </div>
+                                <!-- .panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Tooltips and Popovers
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <h4>Tooltip Demo</h4>
+                                    <div class="tooltip-demo">
+                                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="left" title="Tooltip on left">Tooltip on left</button>
+                                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="top" title="Tooltip on top">Tooltip on top</button>
+                                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="bottom" title="Tooltip on bottom">Tooltip on bottom</button>
+                                        <button type="button" class="btn btn-default" data-toggle="tooltip" data-placement="right" title="Tooltip on right">Tooltip on right</button>
+                                    </div>
+                                    <br>
+                                    <h4>Clickable Popover Demo</h4>
+                                    <div class="tooltip-demo">
+                                        <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="left" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+                                            Popover on left
+                                        </button>
+                                        <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="top" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+                                            Popover on top
+                                        </button>
+                                        <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="bottom" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+                                            Popover on bottom
+                                        </button>
+                                        <button type="button" class="btn btn-default" data-container="body" data-toggle="popover" data-placement="right" data-content="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
+                                            Popover on right
+                                        </button>
+                                    </div>
+                                </div>
+                                <!-- .panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/panels-wells.html
+++ b/pages/panels-wells.html
@@ -230,592 +230,594 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Panels and Wells</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Panels and Wells</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Default Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Default Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-primary">
-                            <div class="panel-heading">
-                                Primary Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-info">
-                            <div class="panel-heading">
-                                Info Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-primary">
+                                <div class="panel-heading">
+                                    Primary Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-success">
-                            <div class="panel-heading">
-                                Success Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-warning">
-                            <div class="panel-heading">
-                                Warning Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-danger">
-                            <div class="panel-heading">
-                                Danger Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
-                            </div>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-green">
-                            <div class="panel-heading">
-                                Green Panel
-                            </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-info">
+                                <div class="panel-heading">
+                                    Info Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
                         </div>
                         <!-- /.col-lg-4 -->
                     </div>
-                    <div class="col-lg-4">
-                        <div class="panel panel-yellow">
-                            <div class="panel-heading">
-                                Yellow Panel
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-success">
+                                <div class="panel-heading">
+                                    Success Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-warning">
+                                <div class="panel-heading">
+                                    Warning Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
-                            <div class="panel-footer">
-                                Panel Footer
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-danger">
+                                <div class="panel-heading">
+                                    Danger Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
                         </div>
                         <!-- /.col-lg-4 -->
                     </div>
-                    <div class="col-lg-4">
-                        <div class="panel panel-red">
-                            <div class="panel-heading">
-                                Red Panel
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-green">
+                                <div class="panel-heading">
+                                    Green Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
-                            <div class="panel-body">
-                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                            </div>
-                            <div class="panel-footer">
-                                Panel Footer
-                            </div>
+                            <!-- /.col-lg-4 -->
                         </div>
-                        <!-- /.col-lg-4 -->
-                    </div>
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Collapsible Accordion Panel Group
+                        <div class="col-lg-4">
+                            <div class="panel panel-yellow">
+                                <div class="panel-heading">
+                                    Yellow Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
                             </div>
-                            <!-- .panel-heading -->
-                            <div class="panel-body">
-                                <div class="panel-group" id="accordion">
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading">
-                                            <h4 class="panel-title">
-                                                <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">Collapsible Group Item #1</a>
-                                            </h4>
-                                        </div>
-                                        <div id="collapseOne" class="panel-collapse collapse in">
-                                            <div class="panel-body">
-                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                            <!-- /.col-lg-4 -->
+                        </div>
+                        <div class="col-lg-4">
+                            <div class="panel panel-red">
+                                <div class="panel-heading">
+                                    Red Panel
+                                </div>
+                                <div class="panel-body">
+                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                                </div>
+                                <div class="panel-footer">
+                                    Panel Footer
+                                </div>
+                            </div>
+                            <!-- /.col-lg-4 -->
+                        </div>
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Collapsible Accordion Panel Group
+                                </div>
+                                <!-- .panel-heading -->
+                                <div class="panel-body">
+                                    <div class="panel-group" id="accordion">
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading">
+                                                <h4 class="panel-title">
+                                                    <a data-toggle="collapse" data-parent="#accordion" href="#collapseOne">Collapsible Group Item #1</a>
+                                                </h4>
+                                            </div>
+                                            <div id="collapseOne" class="panel-collapse collapse in">
+                                                <div class="panel-body">
+                                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading">
-                                            <h4 class="panel-title">
-                                                <a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">Collapsible Group Item #2</a>
-                                            </h4>
-                                        </div>
-                                        <div id="collapseTwo" class="panel-collapse collapse">
-                                            <div class="panel-body">
-                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading">
+                                                <h4 class="panel-title">
+                                                    <a data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">Collapsible Group Item #2</a>
+                                                </h4>
+                                            </div>
+                                            <div id="collapseTwo" class="panel-collapse collapse">
+                                                <div class="panel-body">
+                                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading">
-                                            <h4 class="panel-title">
-                                                <a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">Collapsible Group Item #3</a>
-                                            </h4>
-                                        </div>
-                                        <div id="collapseThree" class="panel-collapse collapse">
-                                            <div class="panel-body">
-                                                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                        <div class="panel panel-default">
+                                            <div class="panel-heading">
+                                                <h4 class="panel-title">
+                                                    <a data-toggle="collapse" data-parent="#accordion" href="#collapseThree">Collapsible Group Item #3</a>
+                                                </h4>
+                                            </div>
+                                            <div id="collapseThree" class="panel-collapse collapse">
+                                                <div class="panel-body">
+                                                    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
+                                <!-- .panel-body -->
                             </div>
-                            <!-- .panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Basic Tabs
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <!-- Nav tabs -->
-                                <ul class="nav nav-tabs">
-                                    <li class="active"><a href="#home" data-toggle="tab">Home</a>
-                                    </li>
-                                    <li><a href="#profile" data-toggle="tab">Profile</a>
-                                    </li>
-                                    <li><a href="#messages" data-toggle="tab">Messages</a>
-                                    </li>
-                                    <li><a href="#settings" data-toggle="tab">Settings</a>
-                                    </li>
-                                </ul>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Basic Tabs
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <!-- Nav tabs -->
+                                    <ul class="nav nav-tabs">
+                                        <li class="active"><a href="#home" data-toggle="tab">Home</a>
+                                        </li>
+                                        <li><a href="#profile" data-toggle="tab">Profile</a>
+                                        </li>
+                                        <li><a href="#messages" data-toggle="tab">Messages</a>
+                                        </li>
+                                        <li><a href="#settings" data-toggle="tab">Settings</a>
+                                        </li>
+                                    </ul>
 
-                                <!-- Tab panes -->
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="home">
-                                        <h4>Home Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                                    </div>
-                                    <div class="tab-pane fade" id="profile">
-                                        <h4>Profile Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                                    </div>
-                                    <div class="tab-pane fade" id="messages">
-                                        <h4>Messages Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                                    </div>
-                                    <div class="tab-pane fade" id="settings">
-                                        <h4>Settings Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                    <!-- Tab panes -->
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="home">
+                                            <h4>Home Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="profile">
+                                            <h4>Profile Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="messages">
+                                            <h4>Messages Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="settings">
+                                            <h4>Settings Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
                                     </div>
                                 </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Pill Tabs
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <!-- Nav tabs -->
-                                <ul class="nav nav-pills">
-                                    <li class="active"><a href="#home-pills" data-toggle="tab">Home</a>
-                                    </li>
-                                    <li><a href="#profile-pills" data-toggle="tab">Profile</a>
-                                    </li>
-                                    <li><a href="#messages-pills" data-toggle="tab">Messages</a>
-                                    </li>
-                                    <li><a href="#settings-pills" data-toggle="tab">Settings</a>
-                                    </li>
-                                </ul>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Pill Tabs
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <!-- Nav tabs -->
+                                    <ul class="nav nav-pills">
+                                        <li class="active"><a href="#home-pills" data-toggle="tab">Home</a>
+                                        </li>
+                                        <li><a href="#profile-pills" data-toggle="tab">Profile</a>
+                                        </li>
+                                        <li><a href="#messages-pills" data-toggle="tab">Messages</a>
+                                        </li>
+                                        <li><a href="#settings-pills" data-toggle="tab">Settings</a>
+                                        </li>
+                                    </ul>
 
-                                <!-- Tab panes -->
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="home-pills">
-                                        <h4>Home Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                    <!-- Tab panes -->
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="home-pills">
+                                            <h4>Home Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="profile-pills">
+                                            <h4>Profile Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="messages-pills">
+                                            <h4>Messages Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
+                                        <div class="tab-pane fade" id="settings-pills">
+                                            <h4>Settings Tab</h4>
+                                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                        </div>
                                     </div>
-                                    <div class="tab-pane fade" id="profile-pills">
-                                        <h4>Profile Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-default">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Default</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-default-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-default-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-default-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-default-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-default-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
                                     </div>
-                                    <div class="tab-pane fade" id="messages-pills">
-                                        <h4>Messages Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-default-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-default-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-default-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-default-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-default-5">Page 5</div>
                                     </div>
-                                    <div class="tab-pane fade" id="settings-pills">
-                                        <h4>Settings Tab</h4>
-                                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                                </div>
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-primary">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Primary</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-primary-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-primary-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-primary-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-primary-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-primary-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-primary-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-primary-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-primary-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-primary-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-primary-5">Page 5</div>
                                     </div>
                                 </div>
                             </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-6 -->
                     </div>
-                    <!-- /.col-lg-6 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-info">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Info</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-info-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-info-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-info-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-info-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-info-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-info-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-info-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-info-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-info-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-info-5">Page 5</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-success">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Success</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-success-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-success-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-success-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-success-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-success-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-success-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-success-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-success-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-success-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-success-5">Page 5</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-warning">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Warning</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-warning-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-warning-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-warning-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-warning-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-warning-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-warning-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-warning-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-warning-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-warning-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-warning-5">Page 5</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel tabbed-panel panel-danger">
+                                <div class="panel-heading clearfix">
+                                    <div class="panel-title pull-left">Tabbed Panel Danger</div>
+                                    <div class="pull-right">
+                                        <ul class="nav nav-tabs">
+                                            <li class="active"><a href="#tab-danger-1" data-toggle="tab">Page 1</a></li>
+                                            <li><a href="#tab-danger-2" data-toggle="tab">Page 2</a></li>
+                                            <li><a href="#tab-danger-3" data-toggle="tab">Page 3</a></li>
+                                            <li class="dropdown">
+                                                <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
+                                                <ul class="dropdown-menu" role="menu">
+                                                    <li><a href="#tab-danger-4" data-toggle="tab">Page 4</a></li>
+                                                    <li><a href="#tab-danger-5" data-toggle="tab">Page 5</a></li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                                <div class="panel-body">
+                                    <div class="tab-content">
+                                        <div class="tab-pane fade in active" id="tab-danger-1">Page 1</div>
+                                        <div class="tab-pane fade" id="tab-danger-2">Page 2</div>
+                                        <div class="tab-pane fade" id="tab-danger-3">Page 3</div>
+                                        <div class="tab-pane fade" id="tab-danger-4">Page 4</div>
+                                        <div class="tab-pane fade" id="tab-danger-5">Page 5</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="well">
+                                <h4>Normal Well</h4>
+                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="well well-lg">
+                                <h4>Large Well</h4>
+                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="well well-sm">
+                                <h4>Small Well</h4>
+                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-4 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <div class="hero-widget well well-sm">
+                                <div class="icon">
+                                    <i class="glyphicon glyphicon-user"></i>
+                                </div>
+                                <div class="text">
+                                    <span class="value">3</span>
+                                    <label class="text-muted">Hero Widget</label>
+                                </div>
+                                <div class="options">
+                                    <a href="javascript:;" class="btn btn-primary btn-lg"><i class="glyphicon glyphicon-plus"></i> Primary Action</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-3">
+                            <div class="hero-widget well well-sm">
+                                <div class="icon">
+                                    <i class="glyphicon glyphicon-star"></i>
+                                </div>
+                                <div class="text">
+                                    <span class="value">614</span>
+                                    <label class="text-muted">Hero Widget</label>
+                                </div>
+                                <div class="options">
+                                    <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-search"></i> Secondary Action</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-3">
+                            <div class="hero-widget well well-sm">
+                                <div class="icon">
+                                    <i class="glyphicon glyphicon-tags"></i>
+                                </div>
+                                <div class="text">
+                                    <span class="value">73</span>
+                                    <label class="text-muted">Hero Widget</label>
+                                </div>
+                                <div class="options">
+                                    <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-search"></i> Secondary Action</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-3">
+                            <div class="hero-widget well well-sm">
+                                <div class="icon">
+                                    <i class="glyphicon glyphicon-cog"></i>
+                                </div>
+                                <div class="text">
+                                    <span class="value">75%</span>
+                                    <label class="text-muted">Hero Widget</label>
+                                </div>
+                                <div class="options">
+                                    <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-wrench"></i> Secondary Action</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="jumbotron">
+                                <h1>Jumbotron</h1>
+                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing.</p>
+                                <p><a class="btn btn-primary btn-lg" role="button">Learn more</a>
+                                </p>
+                            </div>
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-default">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Default</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-default-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-default-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-default-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-default-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-default-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-default-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-default-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-default-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-default-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-default-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-primary">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Primary</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-primary-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-primary-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-primary-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-primary-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-primary-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-primary-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-primary-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-primary-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-primary-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-primary-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-info">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Info</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-info-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-info-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-info-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-info-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-info-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-info-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-info-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-info-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-info-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-info-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-success">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Success</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-success-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-success-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-success-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-success-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-success-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-success-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-success-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-success-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-success-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-success-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-warning">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Warning</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-warning-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-warning-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-warning-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-warning-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-warning-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-warning-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-warning-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-warning-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-warning-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-warning-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel tabbed-panel panel-danger">
-                            <div class="panel-heading clearfix">
-                                <div class="panel-title pull-left">Tabbed Panel Danger</div>
-                                <div class="pull-right">
-                                    <ul class="nav nav-tabs">
-                                        <li class="active"><a href="#tab-danger-1" data-toggle="tab">Page 1</a></li>
-                                        <li><a href="#tab-danger-2" data-toggle="tab">Page 2</a></li>
-                                        <li><a href="#tab-danger-3" data-toggle="tab">Page 3</a></li>
-                                        <li class="dropdown">
-                                            <a href="#" data-toggle="dropdown">More <span class="caret"></span></a>
-                                            <ul class="dropdown-menu" role="menu">
-                                                <li><a href="#tab-danger-4" data-toggle="tab">Page 4</a></li>
-                                                <li><a href="#tab-danger-5" data-toggle="tab">Page 5</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </div>
-                            <div class="panel-body">
-                                <div class="tab-content">
-                                    <div class="tab-pane fade in active" id="tab-danger-1">Page 1</div>
-                                    <div class="tab-pane fade" id="tab-danger-2">Page 2</div>
-                                    <div class="tab-pane fade" id="tab-danger-3">Page 3</div>
-                                    <div class="tab-pane fade" id="tab-danger-4">Page 4</div>
-                                    <div class="tab-pane fade" id="tab-danger-5">Page 5</div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="well">
-                            <h4>Normal Well</h4>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="well well-lg">
-                            <h4>Large Well</h4>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="well well-sm">
-                            <h4>Small Well</h4>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue.</p>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-4 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-sm-3">
-                        <div class="hero-widget well well-sm">
-                            <div class="icon">
-                                <i class="glyphicon glyphicon-user"></i>
-                            </div>
-                            <div class="text">
-                                <span class="value">3</span>
-                                <label class="text-muted">Hero Widget</label>
-                            </div>
-                            <div class="options">
-                                <a href="javascript:;" class="btn btn-primary btn-lg"><i class="glyphicon glyphicon-plus"></i> Primary Action</a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-3">
-                        <div class="hero-widget well well-sm">
-                            <div class="icon">
-                                <i class="glyphicon glyphicon-star"></i>
-                            </div>
-                            <div class="text">
-                                <span class="value">614</span>
-                                <label class="text-muted">Hero Widget</label>
-                            </div>
-                            <div class="options">
-                                <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-search"></i> Secondary Action</a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-3">
-                        <div class="hero-widget well well-sm">
-                            <div class="icon">
-                                <i class="glyphicon glyphicon-tags"></i>
-                            </div>
-                            <div class="text">
-                                <span class="value">73</span>
-                                <label class="text-muted">Hero Widget</label>
-                            </div>
-                            <div class="options">
-                                <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-search"></i> Secondary Action</a>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-3">
-                        <div class="hero-widget well well-sm">
-                            <div class="icon">
-                                <i class="glyphicon glyphicon-cog"></i>
-                            </div>
-                            <div class="text">
-                                <span class="value">75%</span>
-                                <label class="text-muted">Hero Widget</label>
-                            </div>
-                            <div class="options">
-                                <a href="javascript:;" class="btn btn-default btn-lg"><i class="glyphicon glyphicon-wrench"></i> Secondary Action</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="jumbotron">
-                            <h1>Jumbotron</h1>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing, posuere lectus et, fringilla augue. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum tincidunt est vitae ultrices accumsan. Aliquam ornare lacus adipiscing.</p>
-                            <p><a class="btn btn-primary btn-lg" role="button">Learn more</a>
-                            </p>
-                        </div>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
-
         </div>
         <!-- /#wrapper -->
 

--- a/pages/tables.html
+++ b/pages/tables.html
@@ -236,741 +236,744 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Tables</h1>
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Tables</h1>
+                        </div>
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-12 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    DataTables Advanced Tables
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table table-striped table-bordered table-hover" id="dataTables-example">
+                                            <thead>
+                                                <tr>
+                                                    <th>Rendering engine</th>
+                                                    <th>Browser</th>
+                                                    <th>Platform(s)</th>
+                                                    <th>Engine version</th>
+                                                    <th>CSS grade</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr class="odd gradeX">
+                                                    <td>Trident</td>
+                                                    <td>Internet Explorer 4.0</td>
+                                                    <td>Win 95+</td>
+                                                    <td class="center">4</td>
+                                                    <td class="center">X</td>
+                                                </tr>
+                                                <tr class="even gradeC">
+                                                    <td>Trident</td>
+                                                    <td>Internet Explorer 5.0</td>
+                                                    <td>Win 95+</td>
+                                                    <td class="center">5</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="odd gradeA">
+                                                    <td>Trident</td>
+                                                    <td>Internet Explorer 5.5</td>
+                                                    <td>Win 95+</td>
+                                                    <td class="center">5.5</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="even gradeA">
+                                                    <td>Trident</td>
+                                                    <td>Internet Explorer 6</td>
+                                                    <td>Win 98+</td>
+                                                    <td class="center">6</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="odd gradeA">
+                                                    <td>Trident</td>
+                                                    <td>Internet Explorer 7</td>
+                                                    <td>Win XP SP2+</td>
+                                                    <td class="center">7</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="even gradeA">
+                                                    <td>Trident</td>
+                                                    <td>AOL browser (AOL desktop)</td>
+                                                    <td>Win XP</td>
+                                                    <td class="center">6</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Firefox 1.0</td>
+                                                    <td>Win 98+ / OSX.2+</td>
+                                                    <td class="center">1.7</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Firefox 1.5</td>
+                                                    <td>Win 98+ / OSX.2+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Firefox 2.0</td>
+                                                    <td>Win 98+ / OSX.2+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Firefox 3.0</td>
+                                                    <td>Win 2k+ / OSX.3+</td>
+                                                    <td class="center">1.9</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Camino 1.0</td>
+                                                    <td>OSX.2+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Camino 1.5</td>
+                                                    <td>OSX.3+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Netscape 7.2</td>
+                                                    <td>Win 95+ / Mac OS 8.6-9.2</td>
+                                                    <td class="center">1.7</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Netscape Browser 8</td>
+                                                    <td>Win 98SE+</td>
+                                                    <td class="center">1.7</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Netscape Navigator 9</td>
+                                                    <td>Win 98+ / OSX.2+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.0</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.1</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.1</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.2</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.2</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.3</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.3</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.4</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.4</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.5</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.5</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.6</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">1.6</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.7</td>
+                                                    <td>Win 98+ / OSX.1+</td>
+                                                    <td class="center">1.7</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Mozilla 1.8</td>
+                                                    <td>Win 98+ / OSX.1+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Seamonkey 1.1</td>
+                                                    <td>Win 98+ / OSX.2+</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Gecko</td>
+                                                    <td>Epiphany 2.20</td>
+                                                    <td>Gnome</td>
+                                                    <td class="center">1.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>Safari 1.2</td>
+                                                    <td>OSX.3</td>
+                                                    <td class="center">125.5</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>Safari 1.3</td>
+                                                    <td>OSX.3</td>
+                                                    <td class="center">312.8</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>Safari 2.0</td>
+                                                    <td>OSX.4+</td>
+                                                    <td class="center">419.3</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>Safari 3.0</td>
+                                                    <td>OSX.4+</td>
+                                                    <td class="center">522.1</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>OmniWeb 5.5</td>
+                                                    <td>OSX.4+</td>
+                                                    <td class="center">420</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>iPod Touch / iPhone</td>
+                                                    <td>iPod</td>
+                                                    <td class="center">420.1</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Webkit</td>
+                                                    <td>S60</td>
+                                                    <td>S60</td>
+                                                    <td class="center">413</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 7.0</td>
+                                                    <td>Win 95+ / OSX.1+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 7.5</td>
+                                                    <td>Win 95+ / OSX.2+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 8.0</td>
+                                                    <td>Win 95+ / OSX.2+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 8.5</td>
+                                                    <td>Win 95+ / OSX.2+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 9.0</td>
+                                                    <td>Win 95+ / OSX.3+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 9.2</td>
+                                                    <td>Win 88+ / OSX.3+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera 9.5</td>
+                                                    <td>Win 88+ / OSX.3+</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Opera for Wii</td>
+                                                    <td>Wii</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Nokia N800</td>
+                                                    <td>N800</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Presto</td>
+                                                    <td>Nintendo DS browser</td>
+                                                    <td>Nintendo DS</td>
+                                                    <td class="center">8.5</td>
+                                                    <td class="center">C/A<sup>1</sup>
+                                                    </td>
+                                                </tr>
+                                                <tr class="gradeC">
+                                                    <td>KHTML</td>
+                                                    <td>Konqureror 3.1</td>
+                                                    <td>KDE 3.1</td>
+                                                    <td class="center">3.1</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>KHTML</td>
+                                                    <td>Konqureror 3.3</td>
+                                                    <td>KDE 3.3</td>
+                                                    <td class="center">3.3</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>KHTML</td>
+                                                    <td>Konqureror 3.5</td>
+                                                    <td>KDE 3.5</td>
+                                                    <td class="center">3.5</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeX">
+                                                    <td>Tasman</td>
+                                                    <td>Internet Explorer 4.5</td>
+                                                    <td>Mac OS 8-9</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">X</td>
+                                                </tr>
+                                                <tr class="gradeC">
+                                                    <td>Tasman</td>
+                                                    <td>Internet Explorer 5.1</td>
+                                                    <td>Mac OS 7.6-9</td>
+                                                    <td class="center">1</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeC">
+                                                    <td>Tasman</td>
+                                                    <td>Internet Explorer 5.2</td>
+                                                    <td>Mac OS 8-X</td>
+                                                    <td class="center">1</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Misc</td>
+                                                    <td>NetFront 3.1</td>
+                                                    <td>Embedded devices</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeA">
+                                                    <td>Misc</td>
+                                                    <td>NetFront 3.4</td>
+                                                    <td>Embedded devices</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">A</td>
+                                                </tr>
+                                                <tr class="gradeX">
+                                                    <td>Misc</td>
+                                                    <td>Dillo 0.8</td>
+                                                    <td>Embedded devices</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">X</td>
+                                                </tr>
+                                                <tr class="gradeX">
+                                                    <td>Misc</td>
+                                                    <td>Links</td>
+                                                    <td>Text only</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">X</td>
+                                                </tr>
+                                                <tr class="gradeX">
+                                                    <td>Misc</td>
+                                                    <td>Lynx</td>
+                                                    <td>Text only</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">X</td>
+                                                </tr>
+                                                <tr class="gradeC">
+                                                    <td>Misc</td>
+                                                    <td>IE Mobile</td>
+                                                    <td>Windows Mobile 6</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeC">
+                                                    <td>Misc</td>
+                                                    <td>PSP browser</td>
+                                                    <td>PSP</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">C</td>
+                                                </tr>
+                                                <tr class="gradeU">
+                                                    <td>Other browsers</td>
+                                                    <td>All others</td>
+                                                    <td>-</td>
+                                                    <td class="center">-</td>
+                                                    <td class="center">U</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                    <div class="well">
+                                        <h4>DataTables Usage Information</h4>
+                                        <p>DataTables is a very flexible, advanced tables plugin for jQuery. In SB Admin, we are using a specialized version of DataTables built for Bootstrap 3. We have also customized the table headings to use Font Awesome icons in place of images. For complete documentation on DataTables, visit their website at <a target="_blank" href="https://datatables.net/">https://datatables.net/</a>.</p>
+                                        <a class="btn btn-default btn-lg btn-block" target="_blank" href="https://datatables.net/">View DataTables Documentation</a>
+                                    </div>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-12 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Kitchen Sink
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table table-striped table-bordered table-hover">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Basic Table
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Striped Rows
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table table-striped">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Bordered Table
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive table-bordered">
+                                        <table class="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Hover Rows
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table table-hover">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr>
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                        <div class="col-lg-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Context Classes
+                                </div>
+                                <!-- /.panel-heading -->
+                                <div class="panel-body">
+                                    <div class="table-responsive">
+                                        <table class="table">
+                                            <thead>
+                                                <tr>
+                                                    <th>#</th>
+                                                    <th>First Name</th>
+                                                    <th>Last Name</th>
+                                                    <th>Username</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <tr class="success">
+                                                    <td>1</td>
+                                                    <td>Mark</td>
+                                                    <td>Otto</td>
+                                                    <td>@mdo</td>
+                                                </tr>
+                                                <tr class="info">
+                                                    <td>2</td>
+                                                    <td>Jacob</td>
+                                                    <td>Thornton</td>
+                                                    <td>@fat</td>
+                                                </tr>
+                                                <tr class="warning">
+                                                    <td>3</td>
+                                                    <td>Larry</td>
+                                                    <td>the Bird</td>
+                                                    <td>@twitter</td>
+                                                </tr>
+                                                <tr class="danger">
+                                                    <td>4</td>
+                                                    <td>John</td>
+                                                    <td>Smith</td>
+                                                    <td>@jsmith</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                    <!-- /.table-responsive -->
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-6 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-12">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                DataTables Advanced Tables
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-bordered table-hover" id="dataTables-example">
-                                        <thead>
-                                            <tr>
-                                                <th>Rendering engine</th>
-                                                <th>Browser</th>
-                                                <th>Platform(s)</th>
-                                                <th>Engine version</th>
-                                                <th>CSS grade</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr class="odd gradeX">
-                                                <td>Trident</td>
-                                                <td>Internet Explorer 4.0</td>
-                                                <td>Win 95+</td>
-                                                <td class="center">4</td>
-                                                <td class="center">X</td>
-                                            </tr>
-                                            <tr class="even gradeC">
-                                                <td>Trident</td>
-                                                <td>Internet Explorer 5.0</td>
-                                                <td>Win 95+</td>
-                                                <td class="center">5</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="odd gradeA">
-                                                <td>Trident</td>
-                                                <td>Internet Explorer 5.5</td>
-                                                <td>Win 95+</td>
-                                                <td class="center">5.5</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="even gradeA">
-                                                <td>Trident</td>
-                                                <td>Internet Explorer 6</td>
-                                                <td>Win 98+</td>
-                                                <td class="center">6</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="odd gradeA">
-                                                <td>Trident</td>
-                                                <td>Internet Explorer 7</td>
-                                                <td>Win XP SP2+</td>
-                                                <td class="center">7</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="even gradeA">
-                                                <td>Trident</td>
-                                                <td>AOL browser (AOL desktop)</td>
-                                                <td>Win XP</td>
-                                                <td class="center">6</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Firefox 1.0</td>
-                                                <td>Win 98+ / OSX.2+</td>
-                                                <td class="center">1.7</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Firefox 1.5</td>
-                                                <td>Win 98+ / OSX.2+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Firefox 2.0</td>
-                                                <td>Win 98+ / OSX.2+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Firefox 3.0</td>
-                                                <td>Win 2k+ / OSX.3+</td>
-                                                <td class="center">1.9</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Camino 1.0</td>
-                                                <td>OSX.2+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Camino 1.5</td>
-                                                <td>OSX.3+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Netscape 7.2</td>
-                                                <td>Win 95+ / Mac OS 8.6-9.2</td>
-                                                <td class="center">1.7</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Netscape Browser 8</td>
-                                                <td>Win 98SE+</td>
-                                                <td class="center">1.7</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Netscape Navigator 9</td>
-                                                <td>Win 98+ / OSX.2+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.0</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.1</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.1</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.2</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.2</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.3</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.3</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.4</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.4</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.5</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.5</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.6</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">1.6</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.7</td>
-                                                <td>Win 98+ / OSX.1+</td>
-                                                <td class="center">1.7</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Mozilla 1.8</td>
-                                                <td>Win 98+ / OSX.1+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Seamonkey 1.1</td>
-                                                <td>Win 98+ / OSX.2+</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Gecko</td>
-                                                <td>Epiphany 2.20</td>
-                                                <td>Gnome</td>
-                                                <td class="center">1.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>Safari 1.2</td>
-                                                <td>OSX.3</td>
-                                                <td class="center">125.5</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>Safari 1.3</td>
-                                                <td>OSX.3</td>
-                                                <td class="center">312.8</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>Safari 2.0</td>
-                                                <td>OSX.4+</td>
-                                                <td class="center">419.3</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>Safari 3.0</td>
-                                                <td>OSX.4+</td>
-                                                <td class="center">522.1</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>OmniWeb 5.5</td>
-                                                <td>OSX.4+</td>
-                                                <td class="center">420</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>iPod Touch / iPhone</td>
-                                                <td>iPod</td>
-                                                <td class="center">420.1</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Webkit</td>
-                                                <td>S60</td>
-                                                <td>S60</td>
-                                                <td class="center">413</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 7.0</td>
-                                                <td>Win 95+ / OSX.1+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 7.5</td>
-                                                <td>Win 95+ / OSX.2+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 8.0</td>
-                                                <td>Win 95+ / OSX.2+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 8.5</td>
-                                                <td>Win 95+ / OSX.2+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 9.0</td>
-                                                <td>Win 95+ / OSX.3+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 9.2</td>
-                                                <td>Win 88+ / OSX.3+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera 9.5</td>
-                                                <td>Win 88+ / OSX.3+</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Opera for Wii</td>
-                                                <td>Wii</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Nokia N800</td>
-                                                <td>N800</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Presto</td>
-                                                <td>Nintendo DS browser</td>
-                                                <td>Nintendo DS</td>
-                                                <td class="center">8.5</td>
-                                                <td class="center">C/A<sup>1</sup>
-                                                </td>
-                                            </tr>
-                                            <tr class="gradeC">
-                                                <td>KHTML</td>
-                                                <td>Konqureror 3.1</td>
-                                                <td>KDE 3.1</td>
-                                                <td class="center">3.1</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>KHTML</td>
-                                                <td>Konqureror 3.3</td>
-                                                <td>KDE 3.3</td>
-                                                <td class="center">3.3</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>KHTML</td>
-                                                <td>Konqureror 3.5</td>
-                                                <td>KDE 3.5</td>
-                                                <td class="center">3.5</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeX">
-                                                <td>Tasman</td>
-                                                <td>Internet Explorer 4.5</td>
-                                                <td>Mac OS 8-9</td>
-                                                <td class="center">-</td>
-                                                <td class="center">X</td>
-                                            </tr>
-                                            <tr class="gradeC">
-                                                <td>Tasman</td>
-                                                <td>Internet Explorer 5.1</td>
-                                                <td>Mac OS 7.6-9</td>
-                                                <td class="center">1</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeC">
-                                                <td>Tasman</td>
-                                                <td>Internet Explorer 5.2</td>
-                                                <td>Mac OS 8-X</td>
-                                                <td class="center">1</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Misc</td>
-                                                <td>NetFront 3.1</td>
-                                                <td>Embedded devices</td>
-                                                <td class="center">-</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeA">
-                                                <td>Misc</td>
-                                                <td>NetFront 3.4</td>
-                                                <td>Embedded devices</td>
-                                                <td class="center">-</td>
-                                                <td class="center">A</td>
-                                            </tr>
-                                            <tr class="gradeX">
-                                                <td>Misc</td>
-                                                <td>Dillo 0.8</td>
-                                                <td>Embedded devices</td>
-                                                <td class="center">-</td>
-                                                <td class="center">X</td>
-                                            </tr>
-                                            <tr class="gradeX">
-                                                <td>Misc</td>
-                                                <td>Links</td>
-                                                <td>Text only</td>
-                                                <td class="center">-</td>
-                                                <td class="center">X</td>
-                                            </tr>
-                                            <tr class="gradeX">
-                                                <td>Misc</td>
-                                                <td>Lynx</td>
-                                                <td>Text only</td>
-                                                <td class="center">-</td>
-                                                <td class="center">X</td>
-                                            </tr>
-                                            <tr class="gradeC">
-                                                <td>Misc</td>
-                                                <td>IE Mobile</td>
-                                                <td>Windows Mobile 6</td>
-                                                <td class="center">-</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeC">
-                                                <td>Misc</td>
-                                                <td>PSP browser</td>
-                                                <td>PSP</td>
-                                                <td class="center">-</td>
-                                                <td class="center">C</td>
-                                            </tr>
-                                            <tr class="gradeU">
-                                                <td>Other browsers</td>
-                                                <td>All others</td>
-                                                <td>-</td>
-                                                <td class="center">-</td>
-                                                <td class="center">U</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                                <div class="well">
-                                    <h4>DataTables Usage Information</h4>
-                                    <p>DataTables is a very flexible, advanced tables plugin for jQuery. In SB Admin, we are using a specialized version of DataTables built for Bootstrap 3. We have also customized the table headings to use Font Awesome icons in place of images. For complete documentation on DataTables, visit their website at <a target="_blank" href="https://datatables.net/">https://datatables.net/</a>.</p>
-                                    <a class="btn btn-default btn-lg btn-block" target="_blank" href="https://datatables.net/">View DataTables Documentation</a>
-                                </div>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Kitchen Sink
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table table-striped table-bordered table-hover">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr>
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr>
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Basic Table
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr>
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr>
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Striped Rows
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table table-striped">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr>
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr>
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Bordered Table
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive table-bordered">
-                                    <table class="table">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr>
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr>
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Hover Rows
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table table-hover">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr>
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr>
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr>
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                    <div class="col-lg-6">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Context Classes
-                            </div>
-                            <!-- /.panel-heading -->
-                            <div class="panel-body">
-                                <div class="table-responsive">
-                                    <table class="table">
-                                        <thead>
-                                            <tr>
-                                                <th>#</th>
-                                                <th>First Name</th>
-                                                <th>Last Name</th>
-                                                <th>Username</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            <tr class="success">
-                                                <td>1</td>
-                                                <td>Mark</td>
-                                                <td>Otto</td>
-                                                <td>@mdo</td>
-                                            </tr>
-                                            <tr class="info">
-                                                <td>2</td>
-                                                <td>Jacob</td>
-                                                <td>Thornton</td>
-                                                <td>@fat</td>
-                                            </tr>
-                                            <tr class="warning">
-                                                <td>3</td>
-                                                <td>Larry</td>
-                                                <td>the Bird</td>
-                                                <td>@twitter</td>
-                                            </tr>
-                                            <tr class="danger">
-                                                <td>4</td>
-                                                <td>John</td>
-                                                <td>Smith</td>
-                                                <td>@jsmith</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <!-- /.table-responsive -->
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-6 -->
-                </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 

--- a/pages/typography.html
+++ b/pages/typography.html
@@ -230,237 +230,240 @@
             </nav>
 
             <div id="page-wrapper">
-                <div class="row">
-                    <div class="col-lg-12">
-                        <h1 class="page-header">Typography</h1>
-                    </div>
-                    <!-- /.col-lg-12 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Headings
-                            </div>
-                            <div class="panel-body">
-                                <h1>Heading 1
-                                    <small>Sub-heading</small>
-                                </h1>
-                                <h2>Heading 2
-                                    <small>Sub-heading</small>
-                                </h2>
-                                <h3>Heading 3
-                                    <small>Sub-heading</small>
-                                </h3>
-                                <h4>Heading 4
-                                    <small>Sub-heading</small>
-                                </h4>
-                                <h5>Heading 5
-                                    <small>Sub-heading</small>
-                                </h5>
-                                <h6>Heading 6
-                                    <small>Sub-heading</small>
-                                </h6>
-                            </div>
-                            <!-- /.panel-body -->
+                <div class="container-fluid">
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <h1 class="page-header">Typography</h1>
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-12 -->
                     </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Paragraphs
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Headings
+                                </div>
+                                <div class="panel-body">
+                                    <h1>Heading 1
+                                        <small>Sub-heading</small>
+                                    </h1>
+                                    <h2>Heading 2
+                                        <small>Sub-heading</small>
+                                    </h2>
+                                    <h3>Heading 3
+                                        <small>Sub-heading</small>
+                                    </h3>
+                                    <h4>Heading 4
+                                        <small>Sub-heading</small>
+                                    </h4>
+                                    <h5>Heading 5
+                                        <small>Sub-heading</small>
+                                    </h5>
+                                    <h6>Heading 6
+                                        <small>Sub-heading</small>
+                                    </h6>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <div class="panel-body">
-                                <p class="lead">This is an example of lead body copy.</p>
-                                <p>This is an example of standard paragraph text. This is an example of <a href="#">link anchor text</a> within body copy.</p>
-                                <p>
-                                    <small>This is an example of small, fine print text.</small>
-                                </p>
-                                <p>
-                                    <strong>This is an example of strong, bold text.</strong>
-                                </p>
-                                <p>
-                                    <em>This is an example of emphasized, italic text.</em>
-                                </p>
-                                <br>
-                                <h4>Alignment Helpers</h4>
-                                <p class="text-left">Left aligned text.</p>
-                                <p class="text-center">Center aligned text.</p>
-                                <p class="text-right">Right aligned text.</p>
-                            </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Emphasis Classes
-                            </div>
-                            <div class="panel-body">
-                                <p class="text-muted">This is an example of muted text.</p>
-                                <p class="text-primary">This is an example of primary text.</p>
-                                <p class="text-success">This is an example of success text.</p>
-                                <p class="text-info">This is an example of info text.</p>
-                                <p class="text-warning">This is an example of warning text.</p>
-                                <p class="text-danger">This is an example of danger text.</p>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Abbreviations
-                            </div>
-                            <div class="panel-body">
-                                <p>The abbreviation of the word attribute is
-                                    <abbr title="attribute">attr</abbr>.</p>
-                                <p>
-                                    <abbr title="HyperText Markup Language" class="initialism">HTML</abbr>is an abbreviation for a programming language.</p>
-                                <br>
-                                <h4>Addresses</h4>
-                                <address>
-                                    <strong>Twitter, Inc.</strong>
-                                    <br>795 Folsom Ave, Suite 600
-                                    <br>San Francisco, CA 94107
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Paragraphs
+                                </div>
+                                <div class="panel-body">
+                                    <p class="lead">This is an example of lead body copy.</p>
+                                    <p>This is an example of standard paragraph text. This is an example of <a href="#">link anchor text</a> within body copy.</p>
+                                    <p>
+                                        <small>This is an example of small, fine print text.</small>
+                                    </p>
+                                    <p>
+                                        <strong>This is an example of strong, bold text.</strong>
+                                    </p>
+                                    <p>
+                                        <em>This is an example of emphasized, italic text.</em>
+                                    </p>
                                     <br>
-                                    <abbr title="Phone">P:</abbr>(123) 456-7890
-                                </address>
-                                <address>
-                                    <strong>Full Name</strong>
+                                    <h4>Alignment Helpers</h4>
+                                    <p class="text-left">Left aligned text.</p>
+                                    <p class="text-center">Center aligned text.</p>
+                                    <p class="text-right">Right aligned text.</p>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Emphasis Classes
+                                </div>
+                                <div class="panel-body">
+                                    <p class="text-muted">This is an example of muted text.</p>
+                                    <p class="text-primary">This is an example of primary text.</p>
+                                    <p class="text-success">This is an example of success text.</p>
+                                    <p class="text-info">This is an example of info text.</p>
+                                    <p class="text-warning">This is an example of warning text.</p>
+                                    <p class="text-danger">This is an example of danger text.</p>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-4 -->
+                    </div>
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Abbreviations
+                                </div>
+                                <div class="panel-body">
+                                    <p>The abbreviation of the word attribute is
+                                        <abbr title="attribute">attr</abbr>.</p>
+                                    <p>
+                                        <abbr title="HyperText Markup Language" class="initialism">HTML</abbr>is an abbreviation for a programming language.</p>
                                     <br>
-                                    <a href="mailto:#">first.last@example.com</a>
-                                </address>
+                                    <h4>Addresses</h4>
+                                    <address>
+                                        <strong>Twitter, Inc.</strong>
+                                        <br>795 Folsom Ave, Suite 600
+                                        <br>San Francisco, CA 94107
+                                        <br>
+                                        <abbr title="Phone">P:</abbr>(123) 456-7890
+                                    </address>
+                                    <address>
+                                        <strong>Full Name</strong>
+                                        <br>
+                                        <a href="mailto:#">first.last@example.com</a>
+                                    </address>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Blockquotes
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Blockquotes
+                                </div>
+                                <div class="panel-body">
+                                    <h4>Default Blockquote</h4>
+                                    <blockquote>
+                                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+                                    </blockquote>
+                                    <h4>Blockquote with Citation</h4>
+                                    <blockquote>
+                                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+                                        <small>Someone famous in
+                                            <cite title="Source Title">Source Title</cite>
+                                        </small>
+                                    </blockquote>
+                                    <h4>Right Aligned Blockquote</h4>
+                                    <blockquote class="pull-right">
+                                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
+                                    </blockquote>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <div class="panel-body">
-                                <h4>Default Blockquote</h4>
-                                <blockquote>
-                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
-                                </blockquote>
-                                <h4>Blockquote with Citation</h4>
-                                <blockquote>
-                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
-                                    <small>Someone famous in
-                                        <cite title="Source Title">Source Title</cite>
-                                    </small>
-                                </blockquote>
-                                <h4>Right Aligned Blockquote</h4>
-                                <blockquote class="pull-right">
-                                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere erat a ante.</p>
-                                </blockquote>
-                            </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Lists
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Lists
+                                </div>
+                                <div class="panel-body">
+                                    <h4>Unordered List</h4>
+                                    <ul>
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                        <li>
+                                            <ul>
+                                                <li>List Item</li>
+                                                <li>List Item</li>
+                                                <li>List Item</li>
+                                            </ul>
+                                        </li>
+                                        <li>List Item</li>
+                                    </ul>
+                                    <h4>Ordered List</h4>
+                                    <ol>
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                    </ol>
+                                    <h4>Unstyled List</h4>
+                                    <ul class="list-unstyled">
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                    </ul>
+                                    <h4>Inline List</h4>
+                                    <ul class="list-inline">
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                        <li>List Item</li>
+                                    </ul>
+                                </div>
+                                <!-- /.panel-body -->
                             </div>
-                            <div class="panel-body">
-                                <h4>Unordered List</h4>
-                                <ul>
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                    <li>
-                                        <ul>
-                                            <li>List Item</li>
-                                            <li>List Item</li>
-                                            <li>List Item</li>
-                                        </ul>
-                                    </li>
-                                    <li>List Item</li>
-                                </ul>
-                                <h4>Ordered List</h4>
-                                <ol>
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                </ol>
-                                <h4>Unstyled List</h4>
-                                <ul class="list-unstyled">
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                </ul>
-                                <h4>Inline List</h4>
-                                <ul class="list-inline">
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                    <li>List Item</li>
-                                </ul>
-                            </div>
-                            <!-- /.panel-body -->
+                            <!-- /.panel -->
                         </div>
-                        <!-- /.panel -->
+                        <!-- /.col-lg-4 -->
                     </div>
-                    <!-- /.col-lg-4 -->
+                    <!-- /.row -->
+                    <div class="row">
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Description Lists
+                                </div>
+                                <div class="panel-body">
+                                    <dl>
+                                        <dt>Standard Description List</dt>
+                                        <dd>Description Text</dd>
+                                        <dt>Description List Title</dt>
+                                        <dd>Description List Text</dd>
+                                    </dl>
+                                    <dl class="dl-horizontal">
+                                        <dt>Horizontal Description List</dt>
+                                        <dd>Description Text</dd>
+                                        <dt>Description List Title</dt>
+                                        <dd>Description List Text</dd>
+                                    </dl>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-4 -->
+                        <div class="col-lg-4">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    Code
+                                </div>
+                                <div class="panel-body">
+                                    <p>This is an example of an inline code element within body copy. Wrap inline code within a
+                                        <code>&lt;code&gt;...&lt;/code&gt;</code>tag.</p>
+                                    <pre>This is an example of preformatted text.</pre>
+                                </div>
+                                <!-- /.panel-body -->
+                            </div>
+                            <!-- /.panel -->
+                        </div>
+                        <!-- /.col-lg-4 -->
+                    </div>
+                    <!-- /.row -->
                 </div>
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Description Lists
-                            </div>
-                            <div class="panel-body">
-                                <dl>
-                                    <dt>Standard Description List</dt>
-                                    <dd>Description Text</dd>
-                                    <dt>Description List Title</dt>
-                                    <dd>Description List Text</dd>
-                                </dl>
-                                <dl class="dl-horizontal">
-                                    <dt>Horizontal Description List</dt>
-                                    <dd>Description Text</dd>
-                                    <dt>Description List Title</dt>
-                                    <dd>Description List Text</dd>
-                                </dl>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                    <div class="col-lg-4">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                Code
-                            </div>
-                            <div class="panel-body">
-                                <p>This is an example of an inline code element within body copy. Wrap inline code within a
-                                    <code>&lt;code&gt;...&lt;/code&gt;</code>tag.</p>
-                                <pre>This is an example of preformatted text.</pre>
-                            </div>
-                            <!-- /.panel-body -->
-                        </div>
-                        <!-- /.panel -->
-                    </div>
-                    <!-- /.col-lg-4 -->
-                </div>
-                <!-- /.row -->
+                <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
 


### PR DESCRIPTION
Bootstrap requires row "divs" to be wrapped in container tags.  These were missing but the spacing was compensated for in the startmin CSS file.  This is why the alignment of the blank page and the other examples did not match when looking at the body content area.

The container tags have been added to template files and the startmin.css file updated.